### PR TITLE
Update GMS to 11.+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services-location:11.0.2'
+    compile 'com.google.android.gms:play-services-location:11.+'
 }


### PR DESCRIPTION
This is required to avoid multiple dex errors when using other plugins that require Google Play Services.
This will work when https://github.com/flutter/plugins/pull/229/files gets merged.