### PR TITLE
Fixed typing of getLocation to be Dart 2 compliant

### DIFF
--- a/lib/location.dart
+++ b/lib/location.dart
@@ -8,7 +8,7 @@ class Location {
 
   Stream<Map<String,double>> _onLocationChanged;
 
-  Future<Map<String,double>> get getLocation =>
+  Future<dynamic> get getLocation =>
       _channel.invokeMethod('getLocation');
 
   Stream<Map<String,double>> get onLocationChanged {


### PR DESCRIPTION
Basically invokeMethod returns a Future<dynamic> so returning a Future<Map<String, double>> was returning a typing error if you run flutter with --enable-dart-2