### PR TITLE
Throw runtime exception on null event sink

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -35,6 +35,7 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
 
 import java.util.HashMap;
+import java.lang.RuntimeException;
 
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.EventChannel.EventSink;
@@ -127,14 +128,18 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
         mLocationCallback = new LocationCallback() {
             @Override
             public void onLocationResult(LocationResult locationResult) {
-                super.onLocationResult(locationResult);
-                Location location = locationResult.getLastLocation();
-                HashMap<String, Double> loc = new HashMap<String, Double>();
-                loc.put("latitude", location.getLatitude());
-                loc.put("longitude", location.getLongitude());
-                loc.put("accuracy", (double) location.getAccuracy());
-                loc.put("altitude", location.getAltitude());
-                events.success(loc);
+                if(events == null) {
+                    super.onLocationResult(locationResult);
+                    Location location = locationResult.getLastLocation();
+                    HashMap<String, Double> loc = new HashMap<String, Double>();
+                    loc.put("latitude", location.getLatitude());
+                    loc.put("longitude", location.getLongitude());
+                    loc.put("accuracy", (double) location.getAccuracy());
+                    loc.put("altitude", location.getAltitude());
+                    events.success(loc);
+                } else {
+                    throw new RuntimeException("Location permission denied");
+                }
             }
         };
     }


### PR DESCRIPTION
Throw a runtime exception if the event sink is null due to permission denied. Appears to be a chance that the event sink will be set to null before this callback occurs.

Experiencing this when using the example code in the ReadMe for a one time location request. If I user repeatedly triggers the code using this sample.

Receive stack trace 
```
E/AndroidRuntime( 4743): java.lang.NullPointerException: Attempt to invoke interface method 'void io.flutter.plugin.common.EventChannel$EventSink.success(java.lang.Object)' on a null object reference
E/AndroidRuntime( 4743): 	at com.lyokone.location.LocationPlugin$2.onLocationResult(LocationPlugin.java:137)
E/AndroidRuntime( 4743): 	at com.google.android.gms.internal.zzcff.zzu(Unknown Source:4)
E/AndroidRuntime( 4743): 	at com.google.android.gms.common.api.internal.zzci.zzb(Unknown Source:8)
E/AndroidRuntime( 4743): 	at com.google.android.gms.common.api.internal.zzcj.handleMessage(Unknown Source:14)
E/AndroidRuntime( 4743): 	at android.os.Handler.dispatchMessage(Handler.java:106)
E/AndroidRuntime( 4743): 	at android.os.Looper.loop(Looper.java:164)
E/AndroidRuntime( 4743): 	at android.app.ActivityThread.main(ActivityThread.java:6494)
E/AndroidRuntime( 4743): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime( 4743): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
E/AndroidRuntime( 4743): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

I will likely change my app code to simply request location periodically and give user the last sample, but a runtime exception is more clear than the null pointer, in my opinion.