### PR TITLE
Fix crash on Android API < 27

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -136,7 +136,9 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
                 loc.put("accuracy", (double) location.getAccuracy());
                 loc.put("altitude", location.getAltitude());
                 loc.put("speed", (double) location.getSpeed());
-                loc.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    loc.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
+                }
                 events.success(loc);
             }
         };
@@ -225,7 +227,9 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
                     loc.put("accuracy", (double) location.getAccuracy());
                     loc.put("altitude", location.getAltitude());
                     loc.put("speed", (double) location.getSpeed());
-                    loc.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        loc.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
+                    }
 
                     if (result != null) {
                         result.success(loc);


### PR DESCRIPTION
getSpeed is not available pre API 27. Added a version check for this call.