### PR TITLE
Add support for isFromMockProvider

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -130,12 +130,15 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
             public void onLocationResult(LocationResult locationResult) {
                 super.onLocationResult(locationResult);
                 Location location = locationResult.getLastLocation();
-                HashMap<String, Double> loc = new HashMap<String, Double>();
+                HashMap<String, Object> loc = new HashMap<>();
                 loc.put("latitude", location.getLatitude());
                 loc.put("longitude", location.getLongitude());
                 loc.put("accuracy", (double) location.getAccuracy());
                 loc.put("altitude", location.getAltitude());
                 loc.put("speed", (double) location.getSpeed());
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                    loc.put("is_from_mock_provider", location.isFromMockProvider());
+                }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     loc.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
                 }
@@ -224,12 +227,15 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
             @Override
             public void onSuccess(Location location) {
                 if (location != null) {
-                    HashMap<String, Double> loc = new HashMap<String, Double>();
+                    HashMap<String, Object> loc = new HashMap<>();
                     loc.put("latitude", location.getLatitude());
                     loc.put("longitude", location.getLongitude());
                     loc.put("accuracy", (double) location.getAccuracy());
                     loc.put("altitude", location.getAltitude());
                     loc.put("speed", (double) location.getSpeed());
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                        loc.put("is_from_mock_provider", location.isFromMockProvider());
+                    }
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         loc.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
                     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,10 +13,10 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  Map<String, double> _startLocation;
-  Map<String, double> _currentLocation;
+  LocationSnapshot _startLocation;
+  LocationSnapshot _currentLocation;
 
-  StreamSubscription<Map<String, double>> _locationSubscription;
+  StreamSubscription<LocationSnapshot> _locationSubscription;
 
   Location _location = new Location();
   bool _permission = false;
@@ -33,16 +33,23 @@ class _MyAppState extends State<MyApp> {
     initPlatformState();
 
     _locationSubscription =
-        _location.onLocationChanged().listen((Map<String,double> result) {
+        _location.onLocationChanged().listen((LocationSnapshot result) {
           setState(() {
             _currentLocation = result;
           });
         });
   }
 
+  @override
+  void dispose() {
+    super.dispose();
+
+    _locationSubscription.cancel();
+  }
+
   // Platform messages are asynchronous, so we initialize in an async method.
   initPlatformState() async {
-    Map<String, double> location;
+    LocationSnapshot location;
     // Platform messages may fail, so we use a try/catch PlatformException.
 
     try {
@@ -82,7 +89,7 @@ class _MyAppState extends State<MyApp> {
     } else {
       widgets = [
         new Image.network(
-            "https://maps.googleapis.com/maps/api/staticmap?center=${_currentLocation["latitude"]},${_currentLocation["longitude"]}&zoom=18&size=640x400&key=YOUR_API_KEY")
+            "https://maps.googleapis.com/maps/api/staticmap?center=${_currentLocation.latitude},${_currentLocation.longitude}&zoom=18&size=640x400&key=YOUR_API_KEY")
       ];
     }
 

--- a/lib/location.dart
+++ b/lib/location.dart
@@ -1,29 +1,60 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
 
 class Location {
   static const MethodChannel _channel = const MethodChannel('lyokone/location');
   static const EventChannel _stream = const EventChannel('lyokone/locationstream');
 
-  Stream<Map<String,double>> _onLocationChanged;
+  Stream<LocationSnapshot> _onLocationChanged;
 
-  Future<Map<String, double>> getLocation() => _channel
+  Future<LocationSnapshot> getLocation() => _channel
       .invokeMethod('getLocation')
-      .then((result) => result.cast<String, double>());
+      .then((result) => LocationSnapshot.from(result));
 
-  Future<bool> hasPermission() => _channel
-    .invokeMethod('hasPermission')
-    .then((result) => result == 1);
-  
+  Future<bool> hasPermission() =>
+      _channel.invokeMethod('hasPermission').then((result) => result == 1);
 
-  Stream<Map<String, double>> onLocationChanged() {
+  Stream<LocationSnapshot> onLocationChanged() {
     if (_onLocationChanged == null) {
       _onLocationChanged = _stream
           .receiveBroadcastStream()
-          .map<Map<String, double>>(
-              (element) => element.cast<String, double>());
+          .map<LocationSnapshot>(
+              (element) => LocationSnapshot.from(element));
     }
     return _onLocationChanged;
+  }
+}
+
+@immutable
+class LocationSnapshot {
+  final double latitude;
+  final double longitude;
+  final double accuracy;
+  final double altitude;
+  final double speed;
+  final double speedAccuracy;
+  final bool isFromMockProvider;
+
+  LocationSnapshot.from(Map snapshot)
+      : latitude = snapshot["latitude"],
+        longitude = snapshot["longitude"],
+        accuracy = snapshot["accuracy"],
+        altitude = snapshot["altitude"],
+        speed = snapshot["speed"],
+        speedAccuracy = snapshot["speed_accuracy"],
+        isFromMockProvider = snapshot["is_from_mock_provider"];
+
+  @override
+  String toString() {
+    return 'Location['
+      'latitude=$latitude, '
+      'longitude=$longitude, '
+      'accuracy=${accuracy}, '
+      'altitude=${altitude}, '
+      'speed=${speed}, '
+      'speedAccuracy=${speedAccuracy ?? "???"}, '
+      'isFromMockProvider=${isFromMockProvider ?? "???"}]';
   }
 }


### PR DESCRIPTION
This commit refactors the `HashMap` representation of the location object into `LocationSnapshot`. Also includes `isFromMockProvider` support for Android. 

closes https://github.com/Lyokone/flutterlocation/issues/35