### PR TITLE
Initial permissions handling

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -190,7 +190,7 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
      * Return the current state of the permissions needed.
      */
     private boolean checkPermissions() {
-        int permissionState = ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION);
+        int permissionState = ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION);
         return permissionState == PackageManager.PERMISSION_GRANTED;
     }
 
@@ -259,13 +259,14 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
                 this.result = result;
                 requestPermissions();
                 return;
+            } else {
+                getLastLocation(result);
             }
-            getLastLocation(result);
         } else if(call.method.equals("hasPermission")) {
             if(checkPermissions()) {
                 result.success(1);
             } else {
-                result.error("PERMISSION_DENIED", "The user explicitly denied the use of location services for this app or location services are currently disabled in Settings.", null);
+                result.success(0);
             }
         } else {
             result.notImplemented();
@@ -276,7 +277,8 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
     public void onListen(Object arguments, final EventSink eventsSink) {
         events = eventsSink;
         if (!checkPermissions()) {
-            requestPermissions();
+            String errorMessage = "Location runtime permission has not been granted";
+            Log.e(METHOD_CHANNEL_NAME, errorMessage);
             return;
         }
         getLastLocation(null);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,13 +31,6 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     initPlatformState();
-
-    _locationSubscription =
-        _location.onLocationChanged().listen((Map<String,double> result) {
-          setState(() {
-            _currentLocation = result;
-          });
-        });
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
@@ -70,6 +63,12 @@ class _MyAppState extends State<MyApp> {
         _startLocation = location;
     });
 
+    _locationSubscription =
+      _location.onLocationChanged().listen((Map<String,double> result) {
+        setState(() {
+          _currentLocation = result;
+        });
+      });
   }
 
   @override


### PR DESCRIPTION
There was an issue with initial permissions handling: `requestPermissions` method is asynchronous, so it was wrong to invoke `getLastLocation(result);` before user allowed us to do so. 
I suppose this fixes #53.

Additionally, I propose to not to throw when `hasPermission` return false, cause it is basically not an error - it is just a fact of its state :)

And the last change is about location change stream - it is described in comments that we should wait for permissions, but again as they are asynchronous it is hard to do so without major code changes. So I propose to log a message and for now just moved stream subscription in the sample app.