### PR TITLE
Add timestamp to location

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -136,6 +136,7 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
                 loc.put("accuracy", (double) location.getAccuracy());
                 loc.put("altitude", location.getAltitude());
                 loc.put("speed", (double) location.getSpeed());
+                loc.put("time", (double) location.getTime());
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     loc.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
                 }

--- a/ios/Classes/LocationPlugin.m
+++ b/ios/Classes/LocationPlugin.m
@@ -117,6 +117,7 @@
                                                           @"altitude": @(location.altitude),
                                                           @"speed": @(location.speed),
                                                           @"speed_accuracy": @(0.0),
+                                                          @"time": @(location.timestamp.timeIntervalSince1970 * 1000) // NSTimeInterval is seconds and we want millis
                                                           };
 
     if (self.locationWanted) {


### PR DESCRIPTION
This addresses issue #89 by adding the appropriate platform code for iOS and Android to load the timestamp into the returned data structure.