### PR TITLE
Android - Fixed Location.getLocation() returning null due to getLastLocation() not having a last location

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -226,7 +226,7 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
             public void onSuccess(Location location) {
                 if (location != null) {
                     handleGetLastLocationResponse(location, result);
-                } else if (isLocationEnanbled()) {
+                } else if (isLocationEnabled()) {
                     // Last location is null requestLocationUpdates required
                     mFusedLocationClient.requestLocationUpdates(mLocationRequest, new LocationCallback() {
                         @Override
@@ -346,19 +346,19 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
         events = null;
     }
 
-    private boolean isLocationEnanbled() {
+    private boolean isLocationEnabled() {
         LocationManager lm = (LocationManager)activity.getSystemService(Context.LOCATION_SERVICE);
-        boolean gps_enabled = false;
-        boolean network_enabled = false;
+        boolean gpsEnabled = false;
+        boolean networkEnabled = false;
 
         try {
-            gps_enabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
+            gpsEnabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
         } catch(Exception ex) {}
 
         try {
-            network_enabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+            networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
         } catch(Exception ex) {}
 
-        return gps_enabled || network_enabled;
+        return gpsEnabled || networkEnabled;
     }
 }

--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -216,7 +216,7 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler {
         mFusedLocationClient.getLastLocation().addOnSuccessListener(new OnSuccessListener<Location>() {
             @Override
             public void onSuccess(Location location) {
-                if (location == null) {
+                if (location != null) {
                     handleGetLastLocationResponse(location, result);
                 } else {
                     getCurrentLocation();


### PR DESCRIPTION
'getLastLocation()' can return null in a number of scenarios. https://developer.android.com/training/location/retrieve-current#GetLocation

In these cases '_location.getLocation();' would return an error. 

This fix causes '_location.getLocation();' to request then return the current location in this scenario. 

This fixes 
https://github.com/Lyokone/flutterlocation/issues/103
https://github.com/Lyokone/flutterlocation/issues/102
https://github.com/Lyokone/flutterlocation/issues/66
https://github.com/Lyokone/flutterlocation/issues/82

