### PR TITLE
Add min sdk version requirements on AndroidManifest and added more description

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ NSLocationAlwaysUsageDescription
 ```
 **Warning:** there is a currently a bug in iOS simulator in which you have to manually select a Location several in order for the Simulator to actually send data. Please keep that in mind when testing in iOS simulator.  
 
+The OnNmeaMessageListener property is only available for minimum SDK of 24.
+
 ### Example App
 The example app uses [Google Maps Flutter Plugin](https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter), add your API Key in the `AndroidManifest.xml` and in `AppDelegate.m` to use the Google Maps plugin. 
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.lyokone.location">
-
+    <uses-sdk android:minSdkVersion="16" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 


### PR DESCRIPTION
Currently flutter supports a minimum SDK version of 16 and all plugins should be able to match it, anything lower than that will probably cause some unwanted issues. We need to add those into Android Manifest and properly document it.