### PR TITLE
Fix multiple getLocation() calls

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -485,7 +485,6 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler, PluginR
                         null);
             }
         }     
-        startRequestingLocation();   
 
         requestLocationStream();
     }


### PR DESCRIPTION
While I use this app and try to call `getLocation()` multiple times from different asynchron functions the library hangs and give me no return value. It's sound like #172. 

I found following note in [FusedLocationProviderClient](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderClient#requestLocationUpdates(com.google.android.gms.location.LocationRequest,%20com.google.android.gms.location.LocationCallback,%20android.os.Looper)) documentation:

> Any previous LocationRequests registered on this LocationListener will be replaced.

I detect that this plugin not prepared for multiple requests. All variables are stored as member variables in the class and this cause that previous calls are replaced by new ones.

I try to move the callback creation to a functional way. I'm not sure if my changes works for the `onLocationChanged()` function too. But it seems like that this will be init by dart as singleton.

I don't add a multiple call support for case that `requestPermission()` is trigged automatically from `getLocation()`. I think this should be handled by developers. 