### PR TITLE
Add ability to check status of network service or GPS service

### DIFF
--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -178,7 +178,9 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler, PluginR
             requestPermissions();
         } else if (call.method.equals("serviceEnabled")) {
             checkServiceEnabled(result);
-        } else if (call.method.equals("requestService")) {
+        } else if (call.method.equals("serviceStatus")) {
+            checkServiceStatus(result);
+        }else if (call.method.equals("requestService")) {
             requestService(result);
         } else {
             result.notImplemented();
@@ -367,7 +369,31 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler, PluginR
         return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION);
     }
 
+    public HashMap<String, Integer> checkServiceStatus(final Result result) {
+        boolean gps_enabled = false;
+        boolean network_enabled = false;
 
+        try {
+            gps_enabled = this.locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+            network_enabled = this.locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+        } catch (Exception ex) {
+            result.error("SERVICE_STATUS_ERROR", "Location service status couldn't be determined", null);
+            HashMap<String, Integer> statusMap = new HashMap<>();
+            statusMap.put("network_enabled", 2);
+            statusMap.put("gps_enabled", 2);
+            return statusMap;
+        }
+        
+        HashMap<String, Integer> statusMap = new HashMap<>();
+        statusMap.put("network_enabled", network_enabled == true ? 1 : 0);
+        statusMap.put("gps_enabled", gps_enabled == true ? 1 : 0);
+        if (result != null) {
+            result.success(statusMap);
+        } 
+        return statusMap;
+    }
+
+    
     public boolean checkServiceEnabled(final Result result) {
         boolean gps_enabled = false;
         boolean network_enabled = false;

--- a/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -180,7 +180,7 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler, PluginR
             checkServiceEnabled(result);
         } else if (call.method.equals("serviceStatus")) {
             checkServiceStatus(result);
-        }else if (call.method.equals("requestService")) {
+        } else if (call.method.equals("requestService")) {
             requestService(result);
         } else {
             result.notImplemented();
@@ -393,7 +393,7 @@ public class LocationPlugin implements MethodCallHandler, StreamHandler, PluginR
         return statusMap;
     }
 
-    
+
     public boolean checkServiceEnabled(final Result result) {
         boolean gps_enabled = false;
         boolean network_enabled = false;

--- a/ios/Classes/LocationPlugin.m
+++ b/ios/Classes/LocationPlugin.m
@@ -115,6 +115,20 @@
         } else {
             result(@(0));
         }
+    } else if ([call.method isEqualToString:@"serviceStatus"]) {      
+        if ([CLLocationManager locationServicesEnabled]) {
+            NSDictionary<NSString*,NSNumber*>* enabledStatusDict = @{
+                                                          @"network_enabled": @(1),
+                                                          @"gps_enabled": @(1)                                                        
+                                                          };
+            result(enabledStatusDict);
+        } else {
+            NSDictionary<NSString*,NSNumber*>* disabledStatusDict = @{
+                                                          @"network_enabled": @(0),
+                                                          @"gps_enabled": @(0)                                                        
+                                                          };
+            result(disabledStatusDict);
+        }
     } else if ([call.method isEqualToString:@"requestService"]) {
         if ([CLLocationManager locationServicesEnabled]) {
             result(@(1));

--- a/lib/location.dart
+++ b/lib/location.dart
@@ -2,6 +2,29 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+/// An enum represents possible status for services
+enum ServiceStatus { disabled, enabled, unkown }
+
+/// A data class that contains status for location service and gps service
+///
+/// both properties will have same value on iOS and thus is always 0.
+class LocationServiceStatus {
+  ServiceStatus networkStatus;
+  ServiceStatus gpsStatus;
+
+  LocationServiceStatus._(this.networkStatus, this.gpsStatus);
+
+  factory LocationServiceStatus.fromMap(Map<String, int> dataMap) {
+    var networkValue = dataMap['network_enabled'];
+    var gpsValue = dataMap['gps_enabled'];
+
+    var networkStatus = ServiceStatus.values[networkValue];
+    var gpsStatus = ServiceStatus.values[gpsValue];
+
+    return LocationServiceStatus._(networkStatus, gpsStatus);
+  }
+}
+
 /// A data class that contains various information about the user's location.
 ///
 /// speedAccuracy cannot be provided on iOS and thus is always 0.
@@ -72,6 +95,11 @@ class Location {
   /// Checks if the location service is enabled
   Future<bool> serviceEnabled() =>
       _channel.invokeMethod('serviceEnabled').then((result) => result == 1);
+
+  /// Checks if the network and GPS service are enabled
+  Future<LocationServiceStatus> serviceStatus() =>
+      _channel.invokeMethod('serviceStatus').then((result) =>
+          LocationServiceStatus.fromMap(result.cast<String, int>()));
 
   /// Request the activate of the location service
   Future<bool> requestService() =>


### PR DESCRIPTION
This PR adds ability to query GPS & Network services status
* **In Android**
There are two services that location can be acquired from. GPS service & Network service.
Most of flutter plugins just return one Boolean value whether any location service is available or not
But in many use cases, developer need to know if certain service (like GPS) is enabled or not
This PR fix this issue, by adding new function **serviceStatus** to query GPS & Network services on Android

* **In IOS**
There is only one service to acquire location from which is **Location Service**, so if **serviceStatus** function is called on IOS, both GPS status & Network status will be the same value that has been returned from Location Service status 