### PR TITLE
fix getlocation method  suspended

### DIFF
--- a/ios/Classes/LocationPlugin.m
+++ b/ios/Classes/LocationPlugin.m
@@ -90,6 +90,7 @@
         if ([self isPermissionGranted]) {
             [self.clLocationManager startUpdatingLocation];
         } else {
+            self.permissionWanted = YES;
             [self requestPermission];
             if ([self isPermissionGranted]) {
                 [self.clLocationManager startUpdatingLocation];


### PR DESCRIPTION
If you change the location to query in the settings midway, the getlocation method will be called again and will be suspended. This problem is fixed