### PR TITLE
Fix class cast exceptions for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.3.6] 07th January 2020
+* Fix ClassCastException errors on some Android phones when requesting Location status.
+
 ## [2.3.5] 10th April 2019
 * Fix incompatibily with headless plugins thanks to ehhc
 * Fix error with iOS when permission already given

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location
 description: A Flutter plugin to easily handle realtime location in iOS and Android. Provides settings for optimizing performance or battery.
-version: 2.3.5
+version: 2.3.6
 author: Guillaume Bernos <guillaume.bernos@gmail.com>
 homepage: https://github.com/Lyokone/flutterlocation
 


### PR DESCRIPTION
Despite the Android documentation  https://developers.google.com/android/reference/com/google/android/gms/location/LocationSettingsResponse.html, we have had reports of crashes like this on certain phone models:

```
java.lang.ClassCastException: com.google.android.gms.common.api.ApiException cannot be cast to com.google.android.gms.common.api.ResolvableApiException
        at com.lyokone.location.LocationPlugin$5.onFailure(LocationPlugin.java:446)
        at com.google.android.gms.tasks.OnFailureCompletionListener$1.run(OnFailureCompletionListener.java:38)
        at android.os.Handler.handleCallback(Handler.java:790)
        at android.os.Handler.dispatchMessage(Handler.java:99)
```

Protect against these "unknown error types" in code.