### PR TITLE
#273 correct timestamp unit in iOS (was: seconds, becomes: milliseconds) aligned with Android

### DIFF
--- a/ios/Classes/LocationPlugin.m
+++ b/ios/Classes/LocationPlugin.m
@@ -220,7 +220,7 @@
           @"speed": @(location.speed),
           @"speed_accuracy": @0.0,
           @"heading": @(location.course),
-          @"time": @((double) timeInSeconds * 1000.0)
+          @"time": @(((double) timeInSeconds) * 1000.0)  // in milliseconds since the epoch
         };
 
     if (self.locationWanted) {

--- a/ios/Classes/LocationPlugin.m
+++ b/ios/Classes/LocationPlugin.m
@@ -220,7 +220,7 @@
           @"speed": @(location.speed),
           @"speed_accuracy": @0.0,
           @"heading": @(location.course),
-          @"time": @((double) timeInSeconds)
+          @"time": @((double) timeInSeconds * 1000.0)
         };
 
     if (self.locationWanted) {


### PR DESCRIPTION
Current iOS implementation returns the timestamp field in the Location object as "seconds since the epoch", whereas Android returns "milliseconds since the epoch".  The return values should be consistent between platforms, so in this pull request I have multiplied the iOS return value by 1000.

Note this will break implementation for some users (e.g. those that have implemented a Platform.isAndroid check to determine if the value is an iOS "seconds" or an Android "milliseconds" value), but the implementation as it stands today is not consistent between platforms so in my opinion should be corrected.  I expect that few people actually use the timestamp field since it is not needed for the typical location implementation, so the negative impact of this 'breaking change' will be very limited.