### PR TITLE
Problem with location being null when onDetachedFromActivity is called.

### DIFF
--- a/location/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/location/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -29,7 +29,6 @@ public class LocationPlugin implements FlutterPlugin, ActivityAware {
 
     private FlutterPluginBinding pluginBinding;
     private ActivityPluginBinding activityBinding;
-    private Activity activity;
 
     public static void registerWith(Registrar registrar) {
         FlutterLocation flutterLocation = new FlutterLocation(registrar.context(), registrar.activity());
@@ -96,7 +95,6 @@ public class LocationPlugin implements FlutterPlugin, ActivityAware {
 
     private void setup(final BinaryMessenger messenger, final Activity activity,
             final PluginRegistry.Registrar registrar) {
-        this.activity = activity;
         if (registrar != null) {
             // V1 embedding setup for activity listeners.
             registrar.addActivityResultListener(location);
@@ -111,7 +109,5 @@ public class LocationPlugin implements FlutterPlugin, ActivityAware {
     private void tearDown() {
         activityBinding.removeActivityResultListener(location);
         activityBinding.removeRequestPermissionsResultListener(location);
-        location = null;
     }
-
 }


### PR DESCRIPTION
The sequence of events in v2 embedding is as follows:

* onAttachToEngine
* onAttachToActivity
* onDetachFromActivity
* onDetachFromEngine.

However in situations where one is using single pre-warmed and cached Flutter Engine, in those scenarios it is not true that `onDetachFromEngine` will always follow `onDetachFromActivity`

The plugin can be detached from the activity and reattached while still being attached to the flutter engine. In cases like this there will be a crash when application resumes. i.e. `onAttachToActivity` will fail with the following stacktrace:

```
java.lang.NullPointerException: Attempt to write to field 'android.app.Activity jdy.a' on a null object reference
        at com.lyokone.location.LocationPlugin.onAttachedToActivity(LocationPlugin.java:68)
        at io.flutter.embedding.engine.FlutterEnginePluginRegistry.attachToActivity(FlutterEnginePluginRegistry.java:315)
        at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onAttach(FlutterActivityAndFragmentDelegate.java:175)
        at io.flutter.embedding.android.FlutterFragment.onAttach(FlutterFragment.java:578)
        at android.support.v4.app.Fragment.performAttach(Fragment.java:2722)
        at android.support.v4.app.FragmentStateManager.attach(FragmentStateManager.java:426)
        at android.support.v4.app.FragmentManager.moveToState(FragmentManager.java:1153)
        at android.support.v4.app.FragmentManager.moveToState(FragmentManager.java:1316)
        at android.support.v4.app.FragmentTransition.addToFirstInLastOut(FragmentTransition.java:1247)
```