### PR TITLE
Fixed location activity for FlutterBoost

### DIFF
--- a/location/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/location/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -72,10 +72,13 @@ public class LocationPlugin implements FlutterPlugin, ActivityAware {
 
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-        location.setActivity(binding.getActivity());
-
-        activityBinding = binding;
-        setup(pluginBinding.getBinaryMessenger(), activityBinding.getActivity(), null);
+        try {
+            location.setActivity(binding.getActivity());
+            activityBinding = binding;
+            setup(pluginBinding.getBinaryMessenger(), activityBinding.getActivity(), null);
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override


### PR DESCRIPTION
Hey!

Using [FlutterBoost](https://github.com/alibaba/flutter_boost) to use Flutter on native apps causes any modules that depends on `flutterlocation` to crash, I've traced the problem to this method, for some reason, being called two times on `FlutterBoostActivity`, crashing the application on `location.setActivity(binding.getActivity());`, since in the second run, `location` is set to `null`.

Simple fix really, figured this could prevent future crashes for anyone else.