### PR TITLE
Added steps on how to set a custom location for the iOS Simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ NSLocationWhenInUseUsageDescription
 NSLocationAlwaysUsageDescription
 ```
 
+Be aware that calls to `getLocation()` may silently fail when using the iOS Simulator if you have not set a location.
+You can do this by following these steps:
+
+1. Open the Simulator and select the "Features" tab.
+2. Hover over "Location" and select "Custom Location...".
+3. From there you can set a custom latitude and longitude which will be used by the Simulator.
+
 ### Web
 
 Nothing to do, the plugin works directly out of box.


### PR DESCRIPTION
I was quite stumped by this for a while, but if there is no location set for the Simulator to use then calls to `Location().getLocation()` will silently fail.

From what I've seen the Simulator can lose it's location when playing around with enabling/disabling the Location Services, and across XCode updates.

I believe this will help out the people having issues with #337 