### PR TITLE
Fix issue where result.success/error can be called multiple times.

### DIFF
--- a/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -163,6 +163,7 @@ class FlutterLocation
                 } else {
                     result.success(0);
                 }
+                result = null;
                 break;
             case REQUEST_CHECK_SETTINGS:
                 if (resultCode == Activity.RESULT_OK) {
@@ -171,6 +172,7 @@ class FlutterLocation
                 }
 
                 result.error("SERVICE_STATUS_DISABLED", "Failed to get location. Location services disabled", null);
+                result = null;
                 return false;
             default:
                 return false;
@@ -308,7 +310,11 @@ class FlutterLocation
         return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION);
     }
 
-    public boolean checkServiceEnabled(final Result result) {
+    /**
+     * Checks whether location services is enabled. Returns the result in the {@link Result}, if
+     * provided.
+     */
+    public boolean checkServiceEnabled(@Nullable final Result result) {
         boolean gps_enabled = false;
         boolean network_enabled = false;
 
@@ -316,7 +322,9 @@ class FlutterLocation
             gps_enabled = this.locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
             network_enabled = this.locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
         } catch (Exception ex) {
-            result.error("SERVICE_STATUS_ERROR", "Location service status couldn't be determined", null);
+            if (result != null) {
+                result.error("SERVICE_STATUS_ERROR", "Location service status couldn't be determined", null);
+            }
             return false;
         }
         if (gps_enabled || network_enabled) {
@@ -334,7 +342,7 @@ class FlutterLocation
     }
 
     public void requestService(final Result result) {
-        if (this.checkServiceEnabled(result)) {
+        if (this.checkServiceEnabled(null)) {
             result.success(1);
             return;
         }

--- a/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -164,7 +164,7 @@ class FlutterLocation
                     result.success(0);
                 }
                 result = null;
-                break;
+                return true;
             case REQUEST_CHECK_SETTINGS:
                 if (resultCode == Activity.RESULT_OK) {
                     startRequestingLocation();
@@ -173,11 +173,10 @@ class FlutterLocation
 
                 result.error("SERVICE_STATUS_DISABLED", "Failed to get location. Location services disabled", null);
                 result = null;
-                return false;
+                return true;
             default:
                 return false;
         }
-        return true;
     }
 
     public void changeSettings(Integer locationAccuracy, Long updateIntervalMilliseconds,
@@ -310,42 +309,25 @@ class FlutterLocation
         return ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.ACCESS_FINE_LOCATION);
     }
 
-    /**
-     * Checks whether location services is enabled. Returns the result in the {@link Result}, if
-     * provided.
-     */
-    public boolean checkServiceEnabled(@Nullable final Result result) {
-        boolean gps_enabled = false;
-        boolean network_enabled = false;
+    /** Checks whether location services is enabled. */
+    public boolean checkServiceEnabled() {
+        boolean gps_enabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);;
+        boolean network_enabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
 
-        try {
-            gps_enabled = this.locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
-            network_enabled = this.locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-        } catch (Exception ex) {
-            if (result != null) {
-                result.error("SERVICE_STATUS_ERROR", "Location service status couldn't be determined", null);
-            }
-            return false;
-        }
-        if (gps_enabled || network_enabled) {
-            if (result != null) {
-                result.success(1);
-            }
-            return true;
-
-        } else {
-            if (result != null) {
-                result.success(0);
-            }
-            return false;
-        }
+        return gps_enabled || network_enabled;
     }
 
     public void requestService(final Result result) {
-        if (this.checkServiceEnabled(null)) {
-            result.success(1);
+        try {
+            if (this.checkServiceEnabled()) {
+                result.success(1);
+                return;
+            }
+        } catch (Exception e) {
+            result.error("SERVICE_STATUS_ERROR", "Location service status couldn't be determined", null);
             return;
         }
+
         this.result = result;
         mSettingsClient.checkLocationSettings(mLocationSettingsRequest).addOnFailureListener(activity,
                 new OnFailureListener() {

--- a/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
+++ b/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
@@ -44,7 +44,7 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
                 onRequestPermission(result);
                 break;
             case "serviceEnabled":
-                location.checkServiceEnabled(result);
+                onServiceEnabled(result);
                 break;
             case "requestService":
                 location.requestService(result);
@@ -118,6 +118,14 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
             result.success(1);
         } else {
             result.success(0);
+        }
+    }
+
+    private void onServiceEnabled(Result result) {
+        try {
+            result.success(location.checkServiceEnabled() ? 1 : 0);
+        } catch (Exception e) {
+            result.error("SERVICE_STATUS_ERROR", "Location service status couldn't be determined", null);
         }
     }
 


### PR DESCRIPTION
This can happen when there is an ongoing subscription to the Event channel, which
triggers requestService without providing a result. This change fixes it by clearing
the saved result each time a value is returned.