### PR TITLE
Add support for always allow location

### DIFF
--- a/location/example/ios/Runner/Info.plist
+++ b/location/example/ios/Runner/Info.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationAlwaysUsageDescription</key>	
-	<string>I need it </string>	
-	<key>NSLocationWhenInUseUsageDescription</key>	
-	<string>Because</string>	
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>I need it </string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Because</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>I need it Always</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/location/ios/Classes/LocationPlugin.m
+++ b/location/ios/Classes/LocationPlugin.m
@@ -168,7 +168,10 @@
         }
     }
 #else
-    if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
+    if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysAndWhenInUseUsageDescription"] != nil) {
+        [self.clLocationManager requestAlwaysAuthorization];
+    }
+    else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] != nil) {
         [self.clLocationManager requestWhenInUseAuthorization];
     }
     else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {


### PR DESCRIPTION
Added `NSLocationAlwaysAndWhenInUseUsageDescription` check to trigger off a `requestAlwaysAuthorization`request. 

This will allow iOS to allow the prompt to be shown to the user if background locations are used etc. 