### PR TITLE
Adds a toMap function to LocationData

### DIFF
--- a/location/test/location_test.dart
+++ b/location/test/location_test.dart
@@ -39,8 +39,16 @@ void main() {
     test('getLocation should convert to map correctly', () async {
       final LocationData receivedLocation = await location.getLocation();
 
-      expect(receivedLocation.toMap(),
-          {'latitude': receivedLocation.latitude, 'longitude': receivedLocation.longitude});
+      expect(receivedLocation.toMap(), {
+        'latitude': receivedLocation.latitude,
+        'longitude': receivedLocation.longitude,
+        'accuracy': null,
+        'altitude': null,
+        'speed': null,
+        'speed_accuracy': null,
+        'heading': null,
+        'time': null
+      });
     });
   });
 

--- a/location/test/location_test.dart
+++ b/location/test/location_test.dart
@@ -35,21 +35,6 @@ void main() {
       expect(receivedLocation.toString(),
           'LocationData<lat: ${receivedLocation.latitude}, long: ${receivedLocation.longitude}>');
     });
-
-    test('getLocation should convert to map correctly', () async {
-      final LocationData receivedLocation = await location.getLocation();
-
-      expect(receivedLocation.toMap(), {
-        'latitude': receivedLocation.latitude,
-        'longitude': receivedLocation.longitude,
-        'accuracy': null,
-        'altitude': null,
-        'speed': null,
-        'speed_accuracy': null,
-        'heading': null,
-        'time': null
-      });
-    });
   });
 
   test('changeSettings', () async {

--- a/location/test/location_test.dart
+++ b/location/test/location_test.dart
@@ -35,6 +35,13 @@ void main() {
       expect(receivedLocation.toString(),
           'LocationData<lat: ${receivedLocation.latitude}, long: ${receivedLocation.longitude}>');
     });
+
+    test('getLocation should convert to map correctly', () async {
+      final LocationData receivedLocation = await location.getLocation();
+
+      expect(receivedLocation.toMap(),
+          {'latitude': receivedLocation.latitude, 'longitude': receivedLocation.longitude});
+    });
   });
 
   test('changeSettings', () async {

--- a/location_platform_interface/lib/src/types.dart
+++ b/location_platform_interface/lib/src/types.dart
@@ -60,18 +60,18 @@ class LocationData {
 
   @override
   String toString() => 'LocationData<lat: $latitude, long: $longitude>';
-  
+
   @override
-  Map<String, dynamic> toMap() {
-    return {
-      'latitude': this.latitude,
-      'longitude': this.longitude,
-      'accuracy': this.accuracy,
-      'altitude': this.altitude,
-      'speed': this.speed,
-      'speed_accuracy': this.speedAccuracy,
-      'heading': this.heading,
-      'time': this.time,
+  Map<String, double> toMap() {
+    return <String, double>{
+      'latitude': latitude,
+      'longitude': longitude,
+      'accuracy': accuracy,
+      'altitude': altitude,
+      'speed': speed,
+      'speed_accuracy': speedAccuracy,
+      'heading': heading,
+      'time': time,
     };
   }
 

--- a/location_platform_interface/lib/src/types.dart
+++ b/location_platform_interface/lib/src/types.dart
@@ -60,6 +60,20 @@ class LocationData {
 
   @override
   String toString() => 'LocationData<lat: $latitude, long: $longitude>';
+  
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'latitude': this.latitude,
+      'longitude': this.longitude,
+      'accuracy': this.accuracy,
+      'altitude': this.altitude,
+      'speed': this.speed,
+      'speed_accuracy': this.speedAccuracy,
+      'heading': this.heading,
+      'time': this.time,
+    };
+  }
 
   @override
   bool operator ==(Object other) =>

--- a/location_platform_interface/test/types_test.dart
+++ b/location_platform_interface/test/types_test.dart
@@ -10,6 +10,32 @@ void main() {
           'LocationData<lat: ${locationData.latitude}, long: ${locationData.longitude}>');
     });
 
+    test('LocationData should be correctly converted to a map', () {
+      final LocationData locationData = LocationData.fromMap(
+          <String, double>{'latitude': 42, 'longitude': 2});
+      expect(locationData.toMap(), {
+        'latitude': 42,
+        'longitude': 2,
+        'accuracy': null,
+        'altitude': null,
+        'speed': null,
+        'speed_accuracy': null,
+        'heading': null,
+        'time': null
+      });
+    });
+
+    test(
+        'LocationData constructed from OriginalLocationData.toMap() should equal OriginalLocationData',
+        () {
+      final LocationData originalLocationData = LocationData.fromMap(
+          <String, double>{'latitude': 42, 'longitude': 2});
+      final LocationData newLocationData =
+          LocationData.fromMap(originalLocationData.toMap());
+      expect(originalLocationData == newLocationData, true);
+      expect(originalLocationData.hashCode == newLocationData.hashCode, true);
+    });
+
     test('LocationData should be equal if all parameters are equals', () {
       final LocationData locationData = LocationData.fromMap(<String, double>{
         'latitude': 42,


### PR DESCRIPTION
I needed a convenience method to persist location data to a db, to load again later. 

The Map outputted by toMap is usable with the LocationData.fromMap constructor.