### PR TITLE
Add grantedLimited enum value to PermissionStatus

### DIFF
--- a/location/example/lib/permission_status.dart
+++ b/location/example/lib/permission_status.dart
@@ -28,9 +28,6 @@ class _PermissionStatusState extends State<PermissionStatusWidget> {
       setState(() {
         _permissionGranted = permissionRequestedResult;
       });
-      if (permissionRequestedResult != PermissionStatus.granted) {
-        return;
-      }
     }
   }
 

--- a/location/lib/location.dart
+++ b/location/lib/location.dart
@@ -49,7 +49,7 @@ class Location {
     return LocationPlatform.instance.hasPermission();
   }
 
-  /// Checks if the app has permission to access location.
+  /// Requests permission to access location.
   ///
   /// If the result is [PermissionStatus.deniedForever], no dialog will be
   /// shown on [requestPermission].

--- a/location_platform_interface/CHANGELOG.md
+++ b/location_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.1] - 24th August 2020
+
+- Add grantedLimited enum value to PermissionStatus to capture the new limited range authorization that iOS 14 is offering.
+
 ## [1.0.0] - 26th March 2020
 
 - Created the platform interface of the Location plugin in order to support Web and macOS (huge thanks to long1eu)

--- a/location_platform_interface/lib/location_platform_interface.dart
+++ b/location_platform_interface/lib/location_platform_interface.dart
@@ -60,7 +60,7 @@ class LocationPlatform extends PlatformInterface {
     throw UnimplementedError();
   }
 
-  /// Checks if the app has permission to access location.
+  /// Requests permission to access location.
   ///
   /// If the result is [PermissionStatus.deniedForever], no dialog will be
   /// shown on [requestPermission].

--- a/location_platform_interface/lib/src/method_channel_location.dart
+++ b/location_platform_interface/lib/src/method_channel_location.dart
@@ -69,48 +69,33 @@ class MethodChannelLocation extends LocationPlatform {
     return LocationData.fromMap(resultMap);
   }
 
-  /// Checks if the app has permission to access location.
-  ///
-  /// If the result is [PermissionStatus.deniedForever], no dialog will be
-  /// shown on [requestPermission].
-  /// Returns a [PermissionStatus] object.
   @override
   Future<PermissionStatus> hasPermission() async {
     final int result = await _methodChannel.invokeMethod('hasPermission');
-    switch (result) {
-      case 0:
-        return PermissionStatus.denied;
-        break;
-      case 1:
-        return PermissionStatus.granted;
-        break;
-      case 2:
-        return PermissionStatus.deniedForever;
-      default:
-        throw PlatformException(code: 'UNKNOWN_NATIVE_MESSAGE');
-    }
+    return _parsePermissionStatus(result);
   }
 
-  /// Checks if the app has permission to access location.
-  ///
-  /// If the result is [PermissionStatus.deniedForever], no dialog will be
-  /// shown on [requestPermission].
-  /// Returns a [PermissionStatus] object.
   @override
   Future<PermissionStatus> requestPermission() async {
     final int result = await _methodChannel.invokeMethod('requestPermission');
+    return _parsePermissionStatus(result);
+  }
 
+  PermissionStatus _parsePermissionStatus(int result) {
     switch (result) {
       case 0:
         return PermissionStatus.denied;
-        break;
       case 1:
         return PermissionStatus.granted;
-        break;
       case 2:
         return PermissionStatus.deniedForever;
+      case 3:
+        return PermissionStatus.grantedLimited;
       default:
-        throw PlatformException(code: 'UNKNOWN_NATIVE_MESSAGE');
+        throw PlatformException(
+          code: 'UNKNOWN_NATIVE_MESSAGE',
+          message: 'Could not decode parsePermissionStatus with $result',
+        );
     }
   }
 

--- a/location_platform_interface/lib/src/types.dart
+++ b/location_platform_interface/lib/src/types.dart
@@ -111,8 +111,11 @@ enum LocationAccuracy {
 
 // Status of a permission request to use location services.
 enum PermissionStatus {
-  /// The permission to use location services has been granted.
+  /// The permission to use location services has been granted for high accuracy.
   granted,
+
+  /// The permission has been granted but for low accuracy. Only valid on iOS 14+.
+  grantedLimited,
 
   /// The permission to use location services has been denied by the user. May
   /// have been denied forever on iOS.

--- a/location_platform_interface/pubspec.yaml
+++ b/location_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location_platform_interface
 description: A common platform interface for the location plugin.
-version: 1.0.0
+version: 1.0.1
 author: Guillaume Bernos <guillaume@bernos.dev>
 homepage: https://github.com/Lyokone/flutterlocation
 

--- a/location_platform_interface/test/method_channel_location_test.dart
+++ b/location_platform_interface/test/method_channel_location_test.dart
@@ -102,6 +102,14 @@ void main() {
       expect(receivedPermission, PermissionStatus.deniedForever);
       receivedPermission = await location.requestPermission();
       expect(receivedPermission, PermissionStatus.deniedForever);
+
+      methodChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+        return 3;
+      });
+      receivedPermission = await location.hasPermission();
+      expect(receivedPermission, PermissionStatus.grantedLimited);
+      receivedPermission = await location.requestPermission();
+      expect(receivedPermission, PermissionStatus.grantedLimited);
     });
 
     test('Should throw if other message is sent', () async {


### PR DESCRIPTION
iOS 14 is adding the concept of "approximate location". More info here: https://radar.io/blog/understanding-approximate-location-in-ios-14

This PR adds a new enum value in `PermissionStatus` that is only returned in iOS to signify that app has access to limited location.