### PR TITLE
Fix order-dependent tests in location_platform_interface

### DIFF
--- a/location_platform_interface/test/location_platform_interface_test.dart
+++ b/location_platform_interface/test/location_platform_interface_test.dart
@@ -11,6 +11,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('$LocationPlatform', () {
+    final defaultInstance = LocationPlatform.instance;
+    tearDown(() {
+      LocationPlatform.instance = defaultInstance;
+    });
+
     test('$MethodChannelLocation is the default instance', () {
       expect(LocationPlatform.instance, isA<MethodChannelLocation>());
     });


### PR DESCRIPTION
The '$MethodChannelLocation is the default instance' test depended on
being the first test, before any of the other tests clobbered the
`LocationPlatform.instance` singleton.

Ensure that tests restore the original `LocationPlatform.instance`
value.

Fixes https://github.com/Lyokone/flutterlocation/issues/366.