### PR TITLE
Remove unneeded dart:async import

### DIFF
--- a/location/lib/location.dart
+++ b/location/lib/location.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:location_platform_interface/location_platform_interface.dart';
 
 export 'package:location_platform_interface/location_platform_interface.dart'

--- a/location/pubspec.yaml
+++ b/location/pubspec.yaml
@@ -5,7 +5,7 @@ author: Guillaume Bernos <guillaume@bernos.dev>
 homepage: https://github.com/Lyokone/flutterlocation
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"
 
 flutter:


### PR DESCRIPTION
By requiring Dart 2.1, this dart:async import will no longer be needed.
As of Dart 2.1, Future and Stream are exported from dart:core.