### PR TITLE
Fix non-activity methods which throw Activity error 

### DIFF
--- a/location/CHANGELOG.md
+++ b/location/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.1.0] 09 October 2020
+
+- Do not throw errors from methods that do not need an activity.
+- [BREAKING] The error thrown is now ActivityNotFoundException which changes the error code
+returned when activity is not found. It used to be NO_ACTIVITY, now it is just error. We
+anticipate this error to be rarely experienced in the wild.
+
 ## [3.0.3] 25th August 2020
 
 - Add capability to return reduced accuracy permission on iOS 14.0

--- a/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -3,6 +3,7 @@ package com.lyokone.location;
 import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -79,7 +80,7 @@ class FlutterLocation
     private int locationPermissionState;
 
     private boolean waitingForPermission = false;
-    private LocationManager locationManager;
+    private final LocationManager locationManager;
 
     public HashMap<Integer, Integer> mapFlutterAccuracy = new HashMap<Integer, Integer>() {
         {
@@ -94,6 +95,7 @@ class FlutterLocation
     FlutterLocation(Context applicationContext, @Nullable Activity activity) {
         this.applicationContext = applicationContext;
         this.activity = activity;
+        this.locationManager = (LocationManager) applicationContext.getSystemService(Context.LOCATION_SERVICE);
     }
 
     FlutterLocation(PluginRegistry.Registrar registrar) {
@@ -105,7 +107,6 @@ class FlutterLocation
         this.activity = activity;
         mFusedLocationClient = LocationServices.getFusedLocationProviderClient(activity);
         mSettingsClient = LocationServices.getSettingsClient(activity);
-        locationManager = (LocationManager) activity.getSystemService(Context.LOCATION_SERVICE);
 
         createLocationCallback();
         createLocationRequest();
@@ -291,12 +292,18 @@ class FlutterLocation
      * Return the current state of the permissions needed.
      */
     public boolean checkPermissions() {
+        if (this.activity == null) {
+            throw new ActivityNotFoundException();
+        }
         this.locationPermissionState = ActivityCompat.checkSelfPermission(activity,
                 Manifest.permission.ACCESS_FINE_LOCATION);
         return this.locationPermissionState == PackageManager.PERMISSION_GRANTED;
     }
 
     public void requestPermissions() {
+        if (this.activity == null) {
+            throw new ActivityNotFoundException();
+        }
         if (checkPermissions()) {
             result.success(1);
             return;
@@ -318,6 +325,9 @@ class FlutterLocation
     }
 
     public void requestService(final Result result) {
+        if (this.activity == null) {
+            throw new ActivityNotFoundException();
+        }
         try {
             if (this.checkServiceEnabled()) {
                 result.success(1);
@@ -362,6 +372,9 @@ class FlutterLocation
     }
 
     public void startRequestingLocation() {
+        if (this.activity == null) {
+            throw new ActivityNotFoundException();
+        }
         mSettingsClient.checkLocationSettings(mLocationSettingsRequest)
                 .addOnSuccessListener(activity, new OnSuccessListener<LocationSettingsResponse>() {
                     @Override

--- a/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
+++ b/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
@@ -25,11 +25,6 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
 
     @Override
     public void onMethodCall(MethodCall call, Result result) {
-        if (location.activity == null) {
-            result.error("NO_ACTIVITY", null, null);
-            return;
-        }
-
         switch (call.method) {
             case "changeSettings":
                 onChangeSettings(call, result);

--- a/location/pubspec.yaml
+++ b/location/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location
 description: A Flutter plugin to easily handle realtime location in iOS and Android. Provides settings for optimizing performance or battery.
-version: 3.0.3
+version: 3.0.4
 author: Guillaume Bernos <guillaume@bernos.dev>
 homepage: https://github.com/Lyokone/flutterlocation
 

--- a/location/pubspec.yaml
+++ b/location/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location
 description: A Flutter plugin to easily handle realtime location in iOS and Android. Provides settings for optimizing performance or battery.
-version: 3.0.4
+version: 3.1.0
 author: Guillaume Bernos <guillaume@bernos.dev>
 homepage: https://github.com/Lyokone/flutterlocation
 


### PR DESCRIPTION
Some methods do not need `activity` to operate. For instance, `serviceEnabled` method can be called with just the application context since it only needs the `LocationManager`. This allows the methods to be used in the background when needed.

Switching to an actual exception makes the code flow better as well since we throw the error where the activity is needed and used. `result.error` vs throwing a RuntimeException result in the same effect from Dart's point of view (they both get converted to `PlatformException`).