### PR TITLE
Fix memory leaks caused due to activity not being reset

### DIFF
--- a/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -14,7 +14,9 @@ import android.location.OnNmeaMessageListener;
 import android.os.Build;
 import android.os.Looper;
 import android.util.Log;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.ResolvableApiException;
 import com.google.android.gms.location.FusedLocationProviderClient;
@@ -28,15 +30,10 @@ import com.google.android.gms.location.LocationSettingsStatusCodes;
 import com.google.android.gms.location.SettingsClient;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
-
-import java.util.HashMap;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
+import java.util.HashMap;
 
 class FlutterLocation
         implements PluginRegistry.RequestPermissionsResultListener, PluginRegistry.ActivityResultListener {
@@ -105,12 +102,25 @@ class FlutterLocation
 
     void setActivity(@Nullable Activity activity) {
         this.activity = activity;
-        mFusedLocationClient = LocationServices.getFusedLocationProviderClient(activity);
-        mSettingsClient = LocationServices.getSettingsClient(activity);
+        if (this.activity != null) {
+            mFusedLocationClient = LocationServices.getFusedLocationProviderClient(activity);
+            mSettingsClient = LocationServices.getSettingsClient(activity);
 
-        createLocationCallback();
-        createLocationRequest();
-        buildLocationSettingsRequest();
+            createLocationCallback();
+            createLocationRequest();
+            buildLocationSettingsRequest();
+        } else {
+            if (mFusedLocationClient != null) {
+                mFusedLocationClient.removeLocationUpdates(mLocationCallback);
+            }
+            mFusedLocationClient = null;
+            mSettingsClient = null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && locationManager != null) {
+                locationManager.removeNmeaListener(mMessageListener);
+                mMessageListener = null;
+            }
+            locationManager = null;
+        }
     }
 
     @Override

--- a/location/android/src/main/java/com/lyokone/location/LocationPlugin.java
+++ b/location/android/src/main/java/com/lyokone/location/LocationPlugin.java
@@ -1,18 +1,13 @@
 package com.lyokone.location;
 
-import android.app.Activity;
-import android.os.Bundle;
-import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugin.common.BinaryMessenger;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * LocationPlugin
@@ -79,6 +74,7 @@ public class LocationPlugin implements FlutterPlugin, ActivityAware {
         activityBinding.removeActivityResultListener(location);
         activityBinding.removeRequestPermissionsResultListener(location);
         activityBinding = null;
+        location.setActivity(null);
     }
 
     @Override

--- a/location/example/android/app/build.gradle
+++ b/location/example/android/app/build.gradle
@@ -54,6 +54,7 @@ flutter {
 }
 
 dependencies {
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.5'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/location/example/android/app/src/main/res/values/strings.xml
+++ b/location/example/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- Needed to force leak canary to run in debug mode, where -->
+  <!--  Junit seems to be in the classpath. -->
+  <!--  Instructions in https://github.com/square/leakcanary/pull/1654. -->
+  <string name="leak_canary_test_class_name">org.assertj.core.api.Assertions</string>
+</resources>

--- a/location/pubspec.yaml
+++ b/location/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  location_platform_interface: ^1.0.0
+  location_platform_interface: ^1.0.1
   location_web: ^1.0.0
 
 dev_dependencies:

--- a/location/pubspec.yaml
+++ b/location/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  location_platform_interface: ^1.0.1
+  location_platform_interface: ^1.0.0
   location_web: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
LocationPlugin currently does not reset the activity when it gets detached, as a result several callbacks are still attached and the Plugin itself is Engine Lifecycle bound which is > activity lifecycle.

This PR 
* Adds leak canary in debug example
* Fixes memory leaks related to activity lifecycle

Leak trace:
* https://gist.github.com/creativepsyco/468faf0bd6510e02cd00a2b62f44c252

I think the plugin itself right now should not use activity at all, instead using either Service or executors to listen to location updates, but that is a bigger refactor which will take some more time.