### PR TITLE
Added NSLocationAlwaysAndWhenInUseUsageDescription key support in plugin

### DIFF
--- a/location/ios/Classes/LocationPlugin.m
+++ b/location/ios/Classes/LocationPlugin.m
@@ -172,6 +172,9 @@
     else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] != nil) {
         [self.clLocationManager requestAlwaysAuthorization];
     }
+    else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysAndWhenInUseUsageDescription"] != nil) {
+        [self.clLocationManager requestAlwaysAuthorization];
+    }
 #endif
     else {
         [NSException raise:NSInternalInconsistencyException format:

--- a/location/pubspec.yaml
+++ b/location/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  location_platform_interface: ^1.0.1
+  location_platform_interface: 
   location_web: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Added support for "NSLocationAlwaysAndWhenInUseUsageDescription" key in plugin so user can grant Always allow permission in all iOS versions.
Resolves #440 