### PR TITLE
Don't set locationManager to null on Activity detach

### DIFF
--- a/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -77,7 +77,7 @@ class FlutterLocation
     private int locationPermissionState;
 
     private boolean waitingForPermission = false;
-    private LocationManager locationManager;
+    private final LocationManager locationManager;
 
     public HashMap<Integer, Integer> mapFlutterAccuracy = new HashMap<Integer, Integer>() {
         {
@@ -119,7 +119,6 @@ class FlutterLocation
                 locationManager.removeNmeaListener(mMessageListener);
                 mMessageListener = null;
             }
-            locationManager = null;
         }
     }
 


### PR DESCRIPTION
LocationManager is application-scoped and thus doesn't need to be set to null on activity reattach