### PR TITLE
Remove default background location access permissions from plugins AndroidManifest on Android.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ dependencies:
 With Flutter 1.12, all the dependencies are automatically added to your project.
 If your project was created before Flutter 1.12, you may need to follow [this](https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects).
 
-To use location background mode on Android you have to use the `enableBackgroundMode({bool enable})` API before trying to access location in the background. Remember that the user has to accept the location permission to `always allow` to use background location. From Android 11 option to `always allow` is not presented on the location permission dialog prompt. The user has to enable it manually from the app settings and this should be explained to the user on a separate UI that redirects user to app's location settings managed by the operating system. More on that topic can be found on [Android developer](https://developer.android.com/training/location/permissions#request-background-location) pages.
+To use location background mode on Android you have to use the `enableBackgroundMode({bool enable})` API before trying to access location in the background and add nescessary permissions. You should place the required permissions in your applications `<your-app>/android/app/src/main/AndroidManifest.xml`:
+```xml
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+```
+Remember that the user has to accept the location permission to `always allow` to use background location. From Android 11 option to `always allow` is not presented on the location permission dialog prompt. The user has to enable it manually from the app settings and this should be explained to the user on a separate UI that redirects user to app's location settings managed by the operating system. More on that topic can be found on [Android developer](https://developer.android.com/training/location/permissions#request-background-location) pages.
 
 ### iOS
 

--- a/location/android/src/main/AndroidManifest.xml
+++ b/location/android/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
   package="com.lyokone.location">
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
 
     <application>
         <service

--- a/location/example/android/app/src/main/AndroidManifest.xml
+++ b/location/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
     package="com.lyokone.locationexample">
 
     <uses-permission android:name="android.permission.INTERNET"/>
-
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+    
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="Location Example"


### PR DESCRIPTION
Because background location permission was added directly to the plugins AndroidManifest it was causing issues when f.e. submitting to Google Play Store as one had to explain why this permission is used in their app even though they don't use background location. To remove this viral permission it was removed from the plugin and now user has to add required permissions in their android Flutter part as shown in the example app.

on-behalf-of: @dkna <contact@dka.io>