### PR TITLE
Always initialize self.clLocationManager, even if !locationServicesEnabled (closes #484)

### DIFF
--- a/location/darwin/Classes/LocationPlugin.m
+++ b/location/darwin/Classes/LocationPlugin.m
@@ -48,11 +48,9 @@
     if (!(self.hasInit)) {
         self.hasInit = YES;
 
-        if ([CLLocationManager locationServicesEnabled]) {
-            self.clLocationManager = [[CLLocationManager alloc] init];
-            self.clLocationManager.delegate = self;
-            self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
-        }
+        self.clLocationManager = [[CLLocationManager alloc] init];
+        self.clLocationManager.delegate = self;
+        self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
     }
 }
 

--- a/location/ios/Classes/LocationPlugin.m
+++ b/location/ios/Classes/LocationPlugin.m
@@ -52,11 +52,9 @@
         NSArray *backgroundModes = [NSBundle.mainBundle objectForInfoDictionaryKey:@"UIBackgroundModes"];
         self.applicationHasLocationBackgroundMode = [backgroundModes containsObject: @"location"];
 
-        if ([CLLocationManager locationServicesEnabled]) {
-            self.clLocationManager = [[CLLocationManager alloc] init];
-            self.clLocationManager.delegate = self;
-            self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
-        }
+        self.clLocationManager = [[CLLocationManager alloc] init];
+        self.clLocationManager.delegate = self;
+        self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
     }
 }
 


### PR DESCRIPTION
Otherwise even if location services turned on later, none of the self.clLocationManager calls will ever work, because there's no other code that initializes this variable.

Since it's always possible for location services to be turned _off_ at runtime, and we don't reset self.clLocationManager when that happens, this variable being set doesn't tell us anything about whether location services are usable or not.