### PR TITLE
allow for Android notification customization

### DIFF
--- a/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -24,6 +24,9 @@ data class NotificationOptions(
         val channelName: String = kDefaultChannelName,
         val title: String = kDefaultNotificationTitle,
         val iconName: String = kDefaultNotificationIconName,
+        val subtitle: String? = null,
+        val description: String? = null,
+        val color: Int? = null,
 )
 
 class BackgroundNotification(
@@ -36,7 +39,13 @@ class BackgroundNotification(
             .setPriority(NotificationCompat.PRIORITY_HIGH)
 
     init {
-        updateNotification(options.title, options.iconName, false)
+        updateNotification(
+                options.title,
+                options.iconName,
+                options.subtitle,
+                options.description,
+                options.color,
+                false)
     }
 
     private fun getDrawableId(iconName: String): Int {
@@ -57,11 +66,28 @@ class BackgroundNotification(
         }
     }
 
-    private fun updateNotification(title: String, iconName: String, notify: Boolean) {
+    private fun updateNotification(
+            title: String,
+            iconName: String,
+            subtitle: String?,
+            description: String?,
+            color: Int?,
+            notify: Boolean
+    ) {
         val iconId = getDrawableId(iconName).let {
             if (it != 0) it else getDrawableId(kDefaultNotificationIconName)
         }
-        builder = builder.setContentTitle(title).setSmallIcon(iconId)
+        builder = builder
+                .setContentTitle(title)
+                .setSmallIcon(iconId)
+
+        builder = if (color != null) {
+            builder.setColor(color).setColorized(true)
+        } else {
+            builder.setColor(0).setColorized(false)
+        }
+        builder = builder.setContentText(subtitle)
+        builder = builder.setSubText(description)
 
         if (notify) {
             val notificationManager = NotificationManagerCompat.from(context)
@@ -74,9 +100,13 @@ class BackgroundNotification(
             updateChannel(options.channelName)
         }
 
-        if (options.title != this.options.title || options.iconName != this.options.iconName) {
-            updateNotification(options.title, options.iconName, isVisible)
-        }
+        updateNotification(
+                options.title,
+                options.iconName,
+                options.subtitle,
+                options.description,
+                options.color,
+                isVisible)
 
         this.options = options
     }

--- a/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -3,6 +3,7 @@ package com.lyokone.location
 import android.Manifest
 import android.app.*
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Binder
@@ -15,6 +16,77 @@ import androidx.core.app.NotificationManagerCompat
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.PluginRegistry
 
+const val kDefaultChannelName: String = "Location background service"
+const val kDefaultNotificationTitle: String = "Location background service running"
+const val kDefaultNotificationIconName: String = "navigation_empty_icon"
+
+data class NotificationOptions(
+        val channelName: String = kDefaultChannelName,
+        val title: String = kDefaultNotificationTitle,
+        val iconName: String = kDefaultNotificationIconName,
+)
+
+class BackgroundNotification(
+        private val context: Context,
+        private val channelId: String,
+        private val notificationId: Int,
+) {
+    private var options: NotificationOptions = NotificationOptions()
+    private var builder: NotificationCompat.Builder = NotificationCompat.Builder(context, channelId)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+
+    init {
+        updateNotification(options.title, options.iconName, false)
+    }
+
+    private fun getDrawableId(iconName: String): Int {
+        return context.resources.getIdentifier(iconName, "drawable", context.packageName)
+    }
+
+    private fun updateChannel(channelName: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = NotificationManagerCompat.from(context)
+            val channel = NotificationChannel(
+                    channelId,
+                    channelName,
+                    NotificationManager.IMPORTANCE_NONE
+            ).apply {
+                lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+            }
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun updateNotification(title: String, iconName: String, notify: Boolean) {
+        val iconId = getDrawableId(iconName).let {
+            if (it != 0) it else getDrawableId(kDefaultNotificationIconName)
+        }
+        builder = builder.setContentTitle(title).setSmallIcon(iconId)
+
+        if (notify) {
+            val notificationManager = NotificationManagerCompat.from(context)
+            notificationManager.notify(notificationId, builder.build())
+        }
+    }
+
+    fun updateOptions(options: NotificationOptions, isVisible: Boolean) {
+        if (options.channelName != this.options.channelName) {
+            updateChannel(options.channelName)
+        }
+
+        if (options.title != this.options.title) {
+            updateNotification(options.title, "", isVisible)
+        }
+
+        this.options = options
+    }
+
+    fun build(): Notification {
+        updateChannel(options.channelName)
+        return builder.build()
+    }
+}
+
 class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResultListener {
     companion object {
         private const val TAG = "FlutterLocationService"
@@ -23,7 +95,6 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
 
         private const val ONGOING_NOTIFICATION_ID = 75418
         private const val CHANNEL_ID = "flutter_location_channel_01"
-        private const val CHANNEL_NAME = "Location background service"
     }
 
     // Binder given to clients
@@ -33,6 +104,8 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
     private var isForeground = false
 
     private var activity: Activity? = null
+
+    private var backgroundNotification: BackgroundNotification? = null
 
     var location: FlutterLocation? = null
         private set
@@ -58,6 +131,11 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         Log.d(TAG, "Creating service.")
 
         location = FlutterLocation(applicationContext, null)
+        backgroundNotification = BackgroundNotification(
+                applicationContext,
+                CHANNEL_ID,
+                ONGOING_NOTIFICATION_ID
+        )
     }
 
     override fun onBind(intent: Intent?): IBinder? {
@@ -74,6 +152,7 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         Log.d(TAG, "Destroying service.")
 
         location = null
+        backgroundNotification = null
 
         super.onDestroy()
     }
@@ -114,20 +193,7 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         } else {
             Log.d(TAG, "Start service in foreground mode.")
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val notificationManager = NotificationManagerCompat.from(this)
-                val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_NONE).apply {
-                    lockscreenVisibility = Notification.VISIBILITY_PRIVATE
-                }
-                notificationManager.createNotificationChannel(channel)
-            }
-
-            val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
-                    .setContentTitle(getText(R.string.notification_title))
-                    .setSmallIcon(R.drawable.navigation_empty_icon)
-                    .setPriority(NotificationCompat.PRIORITY_HIGH)
-                    .build()
-
+            val notification = backgroundNotification!!.build()
             startForeground(ONGOING_NOTIFICATION_ID, notification)
 
             isForeground = true
@@ -139,6 +205,10 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         stopForeground(true)
 
         isForeground = false
+    }
+
+    fun changeNotificationOptions(options: NotificationOptions) {
+        backgroundNotification?.updateOptions(options, isForeground)
     }
 
     fun setActivity(activity: Activity?) {

--- a/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -74,8 +74,8 @@ class BackgroundNotification(
             updateChannel(options.channelName)
         }
 
-        if (options.title != this.options.title) {
-            updateNotification(options.title, "", isVisible)
+        if (options.title != this.options.title || options.iconName != this.options.iconName) {
+            updateNotification(options.title, options.iconName, isVisible)
         }
 
         this.options = options

--- a/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
+++ b/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
@@ -1,8 +1,11 @@
 package com.lyokone.location;
 
+import android.graphics.Color;
 import android.os.Build;
 import android.util.Log;
+
 import androidx.annotation.Nullable;
+
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -201,7 +204,21 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
                     ? passedIconName
                     : FlutterLocationServiceKt.kDefaultNotificationIconName;
 
-            NotificationOptions options = new NotificationOptions(channelName, title, iconName);
+            String subtitle = call.argument("subtitle");
+            String description = call.argument("description");
+            String hexColor = call.argument("color");
+            Integer color = null;
+            if (hexColor != null) {
+                color = Color.parseColor(hexColor);
+            }
+
+            NotificationOptions options = new NotificationOptions(
+                    channelName,
+                    title,
+                    iconName,
+                    subtitle,
+                    description,
+                    color);
             this.locationService.changeNotificationOptions(options);
             result.success(1);
         } catch (Exception e) {

--- a/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
+++ b/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
@@ -206,6 +206,11 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
 
             String subtitle = call.argument("subtitle");
             String description = call.argument("description");
+            Boolean onTapBringToFront = call.argument("onTapBringToFront");
+            if (onTapBringToFront == null) {
+                onTapBringToFront = false;
+            }
+
             String hexColor = call.argument("color");
             Integer color = null;
             if (hexColor != null) {
@@ -218,7 +223,9 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
                     iconName,
                     subtitle,
                     description,
-                    color);
+                    color,
+                    onTapBringToFront
+            );
             this.locationService.changeNotificationOptions(options);
             result.success(1);
         } catch (Exception e) {

--- a/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
+++ b/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
@@ -55,6 +55,9 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
             case "enableBackgroundMode":
                 enableBackgroundMode(call, result);
                 break;
+            case "changeNotificationOptions":
+                onChangeNotificationOptions(call, result);
+                break;
             default:
                 result.notImplemented();
                 break;
@@ -178,6 +181,32 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
             }
         } else {
             result.success(0);
+        }
+    }
+
+    private void onChangeNotificationOptions(MethodCall call, Result result) {
+        try {
+            String passedChannelName = call.argument("channelName");
+            String channelName = passedChannelName != null
+                    ? passedChannelName
+                    : FlutterLocationServiceKt.kDefaultChannelName;
+
+            String passedTitle = call.argument("title");
+            String title = passedTitle != null
+                    ? passedTitle
+                    : FlutterLocationServiceKt.kDefaultNotificationTitle;
+
+            String passedIconName = call.argument("iconName");
+            String iconName = passedIconName != null
+                    ? passedIconName
+                    : FlutterLocationServiceKt.kDefaultNotificationIconName;
+
+            NotificationOptions options = new NotificationOptions(channelName, title, iconName);
+            this.locationService.changeNotificationOptions(options);
+            result.success(1);
+        } catch (Exception e) {
+            result.error("CHANGE_NOTIFICATION_OPTIONS_ERROR",
+                    "An unexpected error happened during notification options change:" + e.getMessage(), null);
         }
     }
 }

--- a/location/android/src/main/res/values/strings.xml
+++ b/location/android/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="notification_title">Background location service running</string>
-</resources>

--- a/location/example/android/app/src/main/res/drawable/circle.xml
+++ b/location/example/android/app/src/main/res/drawable/circle.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@android:color/black"/>
+    <size
+        android:height="24dp"
+        android:width="24dp"/>
+</shape>

--- a/location/example/android/app/src/main/res/drawable/square.xml
+++ b/location/example/android/app/src/main/res/drawable/square.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/black"/>
+    <size
+        android:height="24dp"
+        android:width="24dp"/>
+</shape>

--- a/location/example/lib/change_notification.dart
+++ b/location/example/lib/change_notification.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:location/location.dart';
+
+class ChangeNotificationWidget extends StatefulWidget {
+  const ChangeNotificationWidget({Key key}) : super(key: key);
+
+  @override
+  _ChangeNotificationWidgetState createState() =>
+      _ChangeNotificationWidgetState();
+}
+
+class _ChangeNotificationWidgetState extends State<ChangeNotificationWidget> {
+  final Location _location = Location();
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _channelController = TextEditingController(
+    text: 'Location background service',
+  );
+  final TextEditingController _titleController = TextEditingController(
+    text: 'Location background service running',
+  );
+
+  String _iconName = 'navigation_empty_icon';
+
+  @override
+  void dispose() {
+    _channelController.dispose();
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!Platform.isAndroid) {
+      return const SizedBox();
+    }
+
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Android Notification Settings',
+            style: Theme.of(context).textTheme.bodyText1,
+          ),
+          const SizedBox(height: 4),
+          TextFormField(
+            controller: _channelController,
+            decoration: const InputDecoration(
+              labelText: 'Channel Name',
+            ),
+          ),
+          const SizedBox(height: 4),
+          TextFormField(
+            controller: _titleController,
+            decoration: const InputDecoration(
+              labelText: 'Notification Title',
+            ),
+          ),
+          const SizedBox(height: 4),
+          DropdownButtonFormField<String>(
+            value: _iconName,
+            onChanged: (String value) {
+              setState(() {
+                _iconName = value;
+              });
+            },
+            items: const <DropdownMenuItem<String>>[
+              DropdownMenuItem<String>(
+                value: 'navigation_empty_icon',
+                child: Text('Empty'),
+              ),
+              DropdownMenuItem<String>(
+                value: 'circle',
+                child: Text('Circle'),
+              ),
+              DropdownMenuItem<String>(
+                value: 'square',
+                child: Text('Square'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          RaisedButton(
+            onPressed: () {
+              _location.changeNotificationOptions(
+                channelName: _channelController.text,
+                title: _titleController.text,
+                iconName: _iconName,
+              );
+            },
+            child: const Text('Change'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/location/example/lib/main.dart
+++ b/location/example/lib/main.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:location/location.dart';
 import 'package:location_example/enable_in_background.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'change_notification.dart';
 import 'get_location.dart';
 import 'listen_location.dart';
 import 'permission_status.dart';
@@ -83,20 +86,24 @@ class _MyHomePageState extends State<MyHomePage> {
           )
         ],
       ),
-      body: Container(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          children: const <Widget>[
-            PermissionStatusWidget(),
-            Divider(height: 32),
-            ServiceEnabledWidget(),
-            Divider(height: 32),
-            GetLocationWidget(),
-            Divider(height: 32),
-            ListenLocationWidget(),
-            Divider(height: 32),
-            EnableInBackgroundWidget(),
-          ],
+      body: SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            children: const <Widget>[
+              PermissionStatusWidget(),
+              Divider(height: 32),
+              ServiceEnabledWidget(),
+              Divider(height: 32),
+              GetLocationWidget(),
+              Divider(height: 32),
+              ListenLocationWidget(),
+              Divider(height: 32),
+              EnableInBackgroundWidget(),
+              Divider(height: 32),
+              ChangeNotificationWidget(),
+            ],
+          ),
         ),
       ),
     );

--- a/location/example/lib/main.dart
+++ b/location/example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:location/location.dart';
 import 'package:location_example/enable_in_background.dart';

--- a/location/lib/location.dart
+++ b/location/lib/location.dart
@@ -84,4 +84,27 @@ class Location {
   Stream<LocationData> get onLocationChanged {
     return LocationPlatform.instance.onLocationChanged;
   }
+
+  /// Change options of sticky background notification on Android.
+  ///
+  /// This method only applies to Android and allows for customizing the
+  /// notification, which is shown when [enableBackgroundMode] is set to true.
+  ///
+  /// Uses [title] as the notification's content title and searches for a
+  /// drawable resource with the given [iconName]. If no matching resource is
+  /// found, no icon is shown.
+  ///
+  /// For Android SDK versions above 25, uses [channelName] for the
+  /// [NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel).
+  Future<bool> changeNotificationOptions({
+    String channelName,
+    String title,
+    String iconName,
+  }) {
+    return LocationPlatform.instance.changeNotificationOptions(
+      channelName: channelName,
+      title: title,
+      iconName: iconName,
+    );
+  }
 }

--- a/location/lib/location.dart
+++ b/location/lib/location.dart
@@ -99,18 +99,22 @@ class Location {
   /// the sub text will be set to [description]. The notification [color] can
   /// also be customized.
   ///
+  /// When [onTapBringToFront] is set to true, tapping the notification will
+  /// bring the activity back to the front.
+  ///
   /// Both [title] and [channelName] will be set to defaults, if no values are
   /// provided. All other null arguments will be ignored.
   ///
   /// For Android SDK versions above 25, uses [channelName] for the
   /// [NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel).
   Future<bool> changeNotificationOptions({
-  String channelName,
-  String title,
-  String iconName,
-  String subtitle,
-  String description,
-  Color color,
+    String channelName,
+    String title,
+    String iconName,
+    String subtitle,
+    String description,
+    Color color,
+    bool onTapBringToFront,
   }) {
     return LocationPlatform.instance.changeNotificationOptions(
       channelName: channelName,
@@ -119,6 +123,7 @@ class Location {
       subtitle: subtitle,
       description: description,
       color: color,
+      onTapBringToFront: onTapBringToFront,
     );
   }
 }

--- a/location/lib/location.dart
+++ b/location/lib/location.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:location_platform_interface/location_platform_interface.dart';
 
 export 'package:location_platform_interface/location_platform_interface.dart'
@@ -89,22 +91,34 @@ class Location {
   ///
   /// This method only applies to Android and allows for customizing the
   /// notification, which is shown when [enableBackgroundMode] is set to true.
+  /// On platforms other than Android, this method will do nothing.
   ///
   /// Uses [title] as the notification's content title and searches for a
   /// drawable resource with the given [iconName]. If no matching resource is
-  /// found, no icon is shown.
+  /// found, no icon is shown. The content text will be set to [subTitle], while
+  /// the sub text will be set to [description]. The notification [color] can
+  /// also be customized.
+  ///
+  /// Both [title] and [channelName] will be set to defaults, if no values are
+  /// provided. All other null arguments will be ignored.
   ///
   /// For Android SDK versions above 25, uses [channelName] for the
   /// [NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel).
   Future<bool> changeNotificationOptions({
-    String channelName,
-    String title,
-    String iconName,
+  String channelName,
+  String title,
+  String iconName,
+  String subtitle,
+  String description,
+  Color color,
   }) {
     return LocationPlatform.instance.changeNotificationOptions(
       channelName: channelName,
       title: title,
       iconName: iconName,
+      subtitle: subtitle,
+      description: description,
+      color: color,
     );
   }
 }

--- a/location_platform_interface/lib/location_platform_interface.dart
+++ b/location_platform_interface/lib/location_platform_interface.dart
@@ -1,5 +1,7 @@
 library location_platform_interface;
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
@@ -95,6 +97,25 @@ class LocationPlatform extends PlatformInterface {
   ///
   /// Throws an error if the app has no permission to access location.
   Stream<LocationData> get onLocationChanged {
+    throw UnimplementedError();
+  }
+
+  /// Change options of sticky background notification on Android.
+  ///
+  /// This method only applies to Android and allows for customizing the
+  /// notification, which is shown when [enableBackgroundMode] is set to true.
+  ///
+  /// Uses [title] as the notification's content title and searches for a
+  /// drawable resource with the given [iconName]. If no matching resource is
+  /// found, no icon is shown.
+  ///
+  /// For Android SDK versions above 25, uses [channelName] for the
+  /// [NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel).
+  Future<bool> changeNotificationOptions({
+    String channelName,
+    String title,
+    String iconName,
+  }) {
     throw UnimplementedError();
   }
 }

--- a/location_platform_interface/lib/location_platform_interface.dart
+++ b/location_platform_interface/lib/location_platform_interface.dart
@@ -113,6 +113,9 @@ class LocationPlatform extends PlatformInterface {
   /// the sub text will be set to [description]. The notification [color] can
   /// also be customized.
   ///
+  /// When [onTapBringToFront] is set to true, tapping the notification will
+  /// bring the activity back to the front.
+  ///
   /// Both [title] and [channelName] will be set to defaults, if no values are
   /// provided. All other null arguments will be ignored.
   ///
@@ -125,6 +128,7 @@ class LocationPlatform extends PlatformInterface {
     String subtitle,
     String description,
     Color color,
+    bool onTapBringToFront,
   }) {
     throw UnimplementedError();
   }

--- a/location_platform_interface/lib/location_platform_interface.dart
+++ b/location_platform_interface/lib/location_platform_interface.dart
@@ -1,6 +1,7 @@
 library location_platform_interface;
 
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -104,10 +105,16 @@ class LocationPlatform extends PlatformInterface {
   ///
   /// This method only applies to Android and allows for customizing the
   /// notification, which is shown when [enableBackgroundMode] is set to true.
+  /// On platforms other than Android, this method will do nothing.
   ///
   /// Uses [title] as the notification's content title and searches for a
   /// drawable resource with the given [iconName]. If no matching resource is
-  /// found, no icon is shown.
+  /// found, no icon is shown. The content text will be set to [subTitle], while
+  /// the sub text will be set to [description]. The notification [color] can
+  /// also be customized.
+  ///
+  /// Both [title] and [channelName] will be set to defaults, if no values are
+  /// provided. All other null arguments will be ignored.
   ///
   /// For Android SDK versions above 25, uses [channelName] for the
   /// [NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel).
@@ -115,6 +122,9 @@ class LocationPlatform extends PlatformInterface {
     String channelName,
     String title,
     String iconName,
+    String subtitle,
+    String description,
+    Color color,
   }) {
     throw UnimplementedError();
   }

--- a/location_platform_interface/lib/src/method_channel_location.dart
+++ b/location_platform_interface/lib/src/method_channel_location.dart
@@ -146,7 +146,12 @@ class MethodChannelLocation extends LocationPlatform {
   ///
   /// Uses [title] as the notification's content title and searches for a
   /// drawable resource with the given [iconName]. If no matching resource is
-  /// found, no icon is shown.
+  /// found, no icon is shown. The content text will be set to [subTitle], while
+  /// the sub text will be set to [description]. The notification [color] can
+  /// also be customized.
+  ///
+  /// Both [title] and [channelName] will be set to defaults, if no values are
+  /// provided. All other null arguments will be ignored.
   ///
   /// For Android SDK versions above 25, uses [channelName] for the
   /// [NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel).
@@ -155,6 +160,9 @@ class MethodChannelLocation extends LocationPlatform {
     String channelName,
     String title,
     String iconName,
+    String subtitle,
+    String description,
+    Color color,
   }) async {
     if (!Platform.isAndroid) {
       // This method only applies to Android.
@@ -162,14 +170,26 @@ class MethodChannelLocation extends LocationPlatform {
       return true;
     }
 
-    final int result = await _methodChannel.invokeMethod(
-      'changeNotificationOptions',
-      <String, dynamic>{
-        'channelName': channelName,
-        'title': title,
-        'iconName': iconName,
-      },
-    );
+    final Map<String, dynamic> data = <String, dynamic>{
+      'channelName': channelName,
+      'title': title,
+      'iconName': iconName,
+    };
+
+    if (subtitle != null) {
+      data['subtitle'] = subtitle;
+    }
+
+    if (description != null) {
+      data['description'] = description;
+    }
+
+    if (color != null) {
+      data['color'] = '#${color.value.toRadixString(16)}';
+    }
+
+    final int result =
+        await _methodChannel.invokeMethod('changeNotificationOptions', data);
 
     return result == 1;
   }

--- a/location_platform_interface/lib/src/method_channel_location.dart
+++ b/location_platform_interface/lib/src/method_channel_location.dart
@@ -57,7 +57,8 @@ class MethodChannelLocation extends LocationPlatform {
   /// Checks if service is enabled in the background mode.
   @override
   Future<bool> isBackgroundModeEnabled() async {
-    final int result = await _methodChannel.invokeMethod('isBackgroundModeEnabled');
+    final int result =
+        await _methodChannel.invokeMethod('isBackgroundModeEnabled');
     return result == 1;
   }
 
@@ -135,5 +136,41 @@ class MethodChannelLocation extends LocationPlatform {
     return _onLocationChanged ??= _eventChannel
         .receiveBroadcastStream()
         .map<LocationData>((dynamic element) => LocationData.fromMap(Map<String, double>.from(element)));
+  }
+
+  /// Change options of sticky background notification on Android.
+  ///
+  /// This method only applies to Android and allows for customizing the
+  /// notification, which is shown when [enableBackgroundMode] is set to true.
+  /// On platforms other than Android, this method will do nothing.
+  ///
+  /// Uses [title] as the notification's content title and searches for a
+  /// drawable resource with the given [iconName]. If no matching resource is
+  /// found, no icon is shown.
+  ///
+  /// For Android SDK versions above 25, uses [channelName] for the
+  /// [NotificationChannel](https://developer.android.com/reference/android/app/NotificationChannel).
+  @override
+  Future<bool> changeNotificationOptions({
+    String channelName,
+    String title,
+    String iconName,
+  }) async {
+    if (!Platform.isAndroid) {
+      // This method only applies to Android.
+      // Do nothing to prevent user from handling a potential error.
+      return true;
+    }
+
+    final int result = await _methodChannel.invokeMethod(
+      'changeNotificationOptions',
+      <String, dynamic>{
+        'channelName': channelName,
+        'title': title,
+        'iconName': iconName,
+      },
+    );
+
+    return result == 1;
   }
 }

--- a/location_platform_interface/lib/src/method_channel_location.dart
+++ b/location_platform_interface/lib/src/method_channel_location.dart
@@ -150,6 +150,9 @@ class MethodChannelLocation extends LocationPlatform {
   /// the sub text will be set to [description]. The notification [color] can
   /// also be customized.
   ///
+  /// When [onTapBringToFront] is set to true, tapping the notification will
+  /// bring the activity back to the front.
+  ///
   /// Both [title] and [channelName] will be set to defaults, if no values are
   /// provided. All other null arguments will be ignored.
   ///
@@ -163,6 +166,7 @@ class MethodChannelLocation extends LocationPlatform {
     String subtitle,
     String description,
     Color color,
+    bool onTapBringToFront,
   }) async {
     if (!Platform.isAndroid) {
       // This method only applies to Android.
@@ -186,6 +190,10 @@ class MethodChannelLocation extends LocationPlatform {
 
     if (color != null) {
       data['color'] = '#${color.value.toRadixString(16)}';
+    }
+
+    if (onTapBringToFront!= null) {
+      data['onTapBringToFront'] = onTapBringToFront;
     }
 
     final int result =

--- a/location_web/lib/location_web.dart
+++ b/location_web/lib/location_web.dart
@@ -91,6 +91,7 @@ class LocationWebPlugin extends LocationPlatform {
     String subtitle,
     String description,
     Color color,
+    bool onTapBringToFront,
   }) async {
     // This method only applies to Android.
     // Do nothing to prevent user from handling a potential UnimplementedError.

--- a/location_web/lib/location_web.dart
+++ b/location_web/lib/location_web.dart
@@ -82,6 +82,17 @@ class LocationWebPlugin extends LocationPlatform {
         .map(_toLocationData);
   }
 
+  @override
+  Future<bool> changeNotificationOptions({
+    String channelName,
+    String title,
+    String iconName,
+  }) async {
+    // This method only applies to Android.
+    // Do nothing to prevent user from handling a potential UnimplementedError.
+    return true;
+  }
+
   LocationData _toLocationData(js.Geoposition result) {
     return LocationData.fromMap(<String, double>{
       'latitude': result.coords.latitude,

--- a/location_web/lib/location_web.dart
+++ b/location_web/lib/location_web.dart
@@ -1,4 +1,5 @@
 import 'dart:html' as js;
+import 'dart:ui';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:location_platform_interface/location_platform_interface.dart';
@@ -87,6 +88,9 @@ class LocationWebPlugin extends LocationPlatform {
     String channelName,
     String title,
     String iconName,
+    String subtitle,
+    String description,
+    Color color,
   }) async {
     // This method only applies to Android.
     // Do nothing to prevent user from handling a potential UnimplementedError.


### PR DESCRIPTION
This PR adds a new method to the `LocationPlatform` interface, as discussed in #483 
```dart
Future<bool> changeNotificationOptions({
  String channelName,
  String title,
  String iconName,
  String subtitle,
  String description,
  Color color,
  bool onTapBringToFront,
});
```

It allows for changing the sticky notification on Android before, during and after `enableBackgroundMode` is called. The current default behavior does not change.

Merging and publishing this PR is highly appreciated, as well as any feedback on the implementation.

Best
Kevin