### PR TITLE
Fix data class parameters declaration

### DIFF
--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -27,13 +27,13 @@ data class NotificationOptions(
         val subtitle: String? = null,
         val description: String? = null,
         val color: Int? = null,
-        val onTapBringToFront: Boolean = false,
+        val onTapBringToFront: Boolean = false
 )
 
 class BackgroundNotification(
         private val context: Context,
         private val channelId: String,
-        private val notificationId: Int,
+        private val notificationId: Int
 ) {
     private var options: NotificationOptions = NotificationOptions()
     private var builder: NotificationCompat.Builder = NotificationCompat.Builder(context, channelId)


### PR DESCRIPTION
Fix build error by removing the extra commas at the end of the Kotlin data class primary constructor parameters declaration. Here is a [https://kotlinlang.org/docs/classes.html#constructors](https://kotlinlang.org/docs/classes.html#constructors)