### PR TITLE
Fixed LocationPlugin.m relative symbolic link.

### DIFF
--- a/packages/location/macos/Classes/LocationPlugin.m
+++ b/packages/location/macos/Classes/LocationPlugin.m
@@ -1,1 +1,1 @@
-darwin/Classes/LocationPlugin.m
+../../darwin/Classes/LocationPlugin.m


### PR DESCRIPTION
There was an invalid relative path to the `darwin/Classes/LocationPlugin.m` file that caused a build error on macOS. This pull request fixes #499, also this bug was mentioned here: https://github.com/Lyokone/flutterlocation/issues/456#issuecomment-748679032

The fixed alias to `LocationPlugin.m` tested on macOS 11.2.1 and confirmed the fix.