### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,19 @@ Remember that the user has to accept the location permission to `always allow` t
 
 And to use it in iOS, you have to add this permission in Info.plist :
 
-```xml
+```
+// The is likely the only one you need. Background location is supported
+// by this -- the caveat is that a blue badge is shown in the status bar
+// when the app is using location service while in the background.
 NSLocationWhenInUseUsageDescription
+
+// Deprecated, use NSLocationAlwaysAndWhenInUseUsageDescription instead.
 NSLocationAlwaysUsageDescription
+
+// Use this very carefully. This key is required only if your iOS app
+// uses APIs that access the user’s location information at all times,
+// even if the app isn't running.
+NSLocationAlwaysAndWhenInUseUsageDescription
 ```
 
 To receive location when application is in background, to Info.plist you have to add property list key :


### PR DESCRIPTION
Updated documentation around location permission int Info.plist.

NSLocationAlwaysUsageDescription is deprecated, and NSLocationAlwaysAndWhenInUseUsageDescription is unlikely required by most apps.