### PR TITLE
Add extras map to LocationData object

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.0
+
+ - **FEAT**: add extras map to LocationData object
+
 ## 4.3.0
 
  - **FIX**: fix location package test.

--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -37,8 +37,6 @@ import io.flutter.plugin.common.PluginRegistry;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 public class FlutterLocation
         implements PluginRegistry.RequestPermissionsResultListener, PluginRegistry.ActivityResultListener {
@@ -269,17 +267,19 @@ public class FlutterLocation
                 loc.put("heading", (double) location.getBearing());
                 loc.put("time", (double) location.getTime());
 
-                final Map<String, Object> data = new HashMap<>(extras.size());
-                for (String key : extras.keySet()) {
-                    final Object value = extras.get(key);
-                    if (value == null || value instanceof Boolean
-                        || value instanceof Integer || value instanceof Long
-                        || value instanceof Double || value instanceof String
-                        || value instanceof byte[] || value instanceof int[]
-                        || value instanceof long[] || value instanceof double[]) {
-                        data.put(key, value);
-                    } else if (value instanceof Float) {
-                        data.put(key, ((Float)value).doubleValue());
+                final Map<String, Object> data = new HashMap<>();
+                if (extras != null) {
+                    for (String key : extras.keySet()) {
+                        final Object value = extras.get(key);
+                        if (value == null || value instanceof Boolean
+                            || value instanceof Integer || value instanceof Long
+                            || value instanceof Double || value instanceof String
+                            || value instanceof byte[] || value instanceof int[]
+                            || value instanceof long[] || value instanceof double[]) {
+                            data.put(key, value);
+                        } else if (value instanceof Float) {
+                            data.put(key, ((Float)value).doubleValue());
+                        }
                     }
                 }
                 loc.put("extras", data);

--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -36,6 +36,9 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 
 import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class FlutterLocation
         implements PluginRegistry.RequestPermissionsResultListener, PluginRegistry.ActivityResultListener {
@@ -265,6 +268,21 @@ public class FlutterLocation
                 }
                 loc.put("heading", (double) location.getBearing());
                 loc.put("time", (double) location.getTime());
+
+                final Map<String, Object> data = new HashMap<>(extras.size());
+                for (String key : extras.keySet()) {
+                    final Object value = extras.get(key);
+                    if (value == null || value instanceof Boolean
+                        || value instanceof Integer || value instanceof Long
+                        || value instanceof Double || value instanceof String
+                        || value instanceof byte[] || value instanceof int[]
+                        || value instanceof long[] || value instanceof double[]) {
+                        data.put(key, value);
+                    } else if (value instanceof Float) {
+                        data.put(key, ((Float)value).doubleValue());
+                    }
+                }
+                loc.put("extras", data);
 
                 if (getLocationResult != null) {
                     getLocationResult.success(loc);

--- a/packages/location/pubspec.yaml
+++ b/packages/location/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location
 description: A Flutter plugin to easily handle realtime location in iOS and Android. Provides settings for optimizing performance or battery.
-version: 4.3.0
+version: 4.4.0
 homepage: https://github.com/Lyokone/flutterlocation
 
 environment:

--- a/packages/location_platform_interface/CHANGELOG.md
+++ b/packages/location_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+ - **FEAT**: add extras map to LocationData object
+
 ## 2.3.0
 
  - **FIX**: add platform tests.

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -21,7 +21,8 @@ class LocationData {
       this.elapsedRealtimeNanos,
       this.elapsedRealtimeUncertaintyNanos,
       this.satelliteNumber,
-      this.provider);
+      this.provider,
+      this.extras);
 
   factory LocationData.fromMap(Map<String, dynamic> dataMap) {
     return LocationData._(
@@ -40,10 +41,11 @@ class LocationData {
       dataMap['elapsedRealtimeUncertaintyNanos'],
       dataMap['satelliteNumber'],
       dataMap['provider'],
+      dataMap['extras'].cast<String, dynamic>(),
     );
   }
 
-  /// Latitude in degrees
+  /// Latitude, in degrees
   final double? latitude;
 
   /// Longitude, in degrees
@@ -109,6 +111,11 @@ class LocationData {
   /// Only available on Android
   /// https://developer.android.com/reference/android/location/Location#getProvider()
   final String? provider;
+
+  /// All the values contained in the extras bundle of an Android Location object.
+  /// Only available on Android
+  /// https://developer.android.com/reference/android/location/Location#getProvider()
+  final Map<String, dynamic>? extras;
 
   @override
   String toString() =>

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -25,6 +25,7 @@ class LocationData {
       this.extras);
 
   factory LocationData.fromMap(Map<String, dynamic> dataMap) {
+    final extras = dataMap['extras'];
     return LocationData._(
       dataMap['latitude'],
       dataMap['longitude'],
@@ -41,7 +42,7 @@ class LocationData {
       dataMap['elapsedRealtimeUncertaintyNanos'],
       dataMap['satelliteNumber'],
       dataMap['provider'],
-      dataMap['extras'].cast<String, dynamic>(),
+      extras != null ? extras.cast<String, dynamic>() : {},
     );
   }
 
@@ -114,7 +115,7 @@ class LocationData {
 
   /// All the values contained in the extras bundle of an Android Location object.
   /// Only available on Android
-  /// https://developer.android.com/reference/android/location/Location#getProvider()
+  /// https://developer.android.com/reference/android/location/Location#getExtras()
   final Map<String, dynamic>? extras;
 
   @override

--- a/packages/location_platform_interface/pubspec.yaml
+++ b/packages/location_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location_platform_interface
 description: A common platform interface for the location plugin.
-version: 2.3.0
+version: 2.4.0
 homepage: https://github.com/Lyokone/flutterlocation
 
 environment:


### PR DESCRIPTION
External GNSS devices are often connected to Android through a mock provider. Because NMEA data sequences cannot be mocked, additional location-specific data is often injected into the mock provider by means of the [extras bundle of the Android Location object](https://developer.android.com/reference/android/location/Location#getExtras()). In order to access this data, the LocationData object of flutterlocation is extended by an additional map property `extras`.