### PR TITLE
fix(ios): issue 621 - getLocation not resolving

### DIFF
--- a/packages/location/ios/Classes/LocationPlugin.m
+++ b/packages/location/ios/Classes/LocationPlugin.m
@@ -126,7 +126,12 @@
         self.locationWanted = YES;
 
         if ([self isPermissionGranted]) {
+          if (self.flutterListening && [self.clLocationManager location] != NULL) {
+            CLLocation* latestLocation = [self.clLocationManager location];
+            [self locationManager:self.clLocationManager didUpdateLocations:@[latestLocation]];
+          } else {
             [self.clLocationManager startUpdatingLocation];
+          }
         } else {
             [self requestPermission];
             if ([self isPermissionGranted]) {


### PR DESCRIPTION
Closes #621 

It seems this issue is only happening if flutter is
already requesting location updates when the call to
getLocation is made.

Potential fix:
In the case where location updates are already running,
and a valid location is already present, return the
latest location to the caller when getLocation is called.

I have tested this implementation and it seems to work on this dummy example app:
[location.zip](https://github.com/Lyokone/flutterlocation/files/7097579/location.zip)
