### PR TITLE
Rework filtering of cached locations to not ignore first 2 locations

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+- **FIX**: Revert #549 and use time of location to determine if location is cached/old
+
 ## 4.3.0
 
  - **FIX**: fix location package test.

--- a/packages/location/pubspec.yaml
+++ b/packages/location/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location
 description: A Flutter plugin to easily handle realtime location in iOS and Android. Provides settings for optimizing performance or battery.
-version: 4.3.0
+version: 4.3.1
 homepage: https://github.com/Lyokone/flutterlocation
 
 environment:


### PR DESCRIPTION
Fixes #665, and potentially #657.

PR removes the fix made in #549 in favor of using the timestamp of the location to determine if the location is cached or old. Currently if a location is returned, and is older than 10 seconds (chosen arbitrarily) the location update is ignored, maybe this should be configurable in `changeSettings`.

Alternatively: should the package even care about cached/old locations? If users only want recent locations, maybe they should implement their own logic using `onLocationChanged` instead of an opinionated implementation of `getLocation`?