### PR TITLE
Make LocationData latitude/longitude not null

### DIFF
--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -42,10 +42,10 @@ class LocationData {
   }
 
   /// Latitude in degrees
-  final double? latitude;
+  final double latitude;
 
   /// Longitude, in degrees
-  final double? longitude;
+  final double longitude;
 
   /// Estimated horizontal accuracy of this location, radial, in meters
   ///


### PR DESCRIPTION
The current declaration of attributes on `LocationData` class does not make sense to me because all the attributes are nullable, why do you want to have a `LocationData` without location values?

Fix: https://github.com/Lyokone/flutterlocation/issues/675