### PR TITLE
Migrate android plugins from jcenter to mavenCentral

### DIFF
--- a/packages/location/android/build.gradle
+++ b/packages/location/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.4.20'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,6 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/packages/location/example/android/build.gradle
+++ b/packages/location/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.4.20'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
jcenter is closing Feb 1 of 2022 and as of writing this PR currently returns a 502 error causing the plugin to fail when building.

This PR does the same as was done in the official Flutter repo
https://github.com/flutter/flutter/issues/82847