### PR TITLE
add : add android foreground mode in Location Platform Interface

### DIFF
--- a/packages/location_platform_interface/lib/location_platform_interface.dart
+++ b/packages/location_platform_interface/lib/location_platform_interface.dart
@@ -53,7 +53,8 @@ class LocationPlatform extends PlatformInterface {
   }
 
   /// Enables or disables service in the background mode.
-  Future<bool> enableBackgroundMode({bool? enable}) {
+  /// isForeground option is only using in Android 10 and above.
+  Future<bool> enableBackgroundMode({bool? enable, bool isForeground = false}) {
     throw UnimplementedError();
   }
 

--- a/packages/location_platform_interface/lib/src/method_channel_location.dart
+++ b/packages/location_platform_interface/lib/src/method_channel_location.dart
@@ -67,12 +67,15 @@ class MethodChannelLocation extends LocationPlatform {
   }
 
   /// Enables or disables service in the background mode.
+  /// isForeground option is only using in Android 10 and above.
   @override
-  Future<bool> enableBackgroundMode({bool? enable}) async {
+  Future<bool> enableBackgroundMode(
+      {bool? enable, bool? isForeground = false}) async {
     final int? result = await _methodChannel!.invokeMethod(
-      'enableBackgroundMode',
-      <String, dynamic>{'enable': enable},
-    );
+        'enableBackgroundMode',
+        !Platform.isAndroid
+            ? <String, dynamic>{'enable': enable}
+            : <String, bool?>{'enable': enable, 'foreground': isForeground});
 
     return result == 1;
   }


### PR DESCRIPTION
https://github.com/Lyokone/flutterlocation/issues/600 

We have added the Foreground option, a preparatory action to enable Android to use Foreground only (without background), to enable Background Mode in the Location Platform Interface package.

If you post it on the package, we will add it to the location package.

I'd appreciate it if you could merge. Have a great day!

---
+ The reason why we need "Foreground Mode Only" is because

https://developer.android.com/training/location/permissions#foreground

When implementing only functions such as the content of the link, you don't have to obtain background permission, so you have to minimize the permission.