### PR TITLE
#690 Prevent Crash on Fine Location Error

### DIFF
--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -414,7 +414,7 @@ public class FlutterLocation
                 });
     }
 
-    private void addNmealListener() {
+    private void addNmeaListener() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             try {
                 if (mMessageListener == null) {


### PR DESCRIPTION
locationManager.addNmeaListener can throw an error if ACCESS_FINE_LOCATION permission is not present (because the user has denied it) [Android Docs](https://developer.android.com/reference/android/location/LocationManager#addNmeaListener(android.location.OnNmeaMessageListener,%20android.os.Handler))  Currently the error is not handled and causes an app crash.

This PR will log the occurance of the error and continue. Not sure if that's the best approach, but should prevent app crash.
