### PR TITLE
Fix: Class 'FlutterLocationService' is not abstract and does not implement abstract member public abstract fun onRequestPermissionsResult

### DIFF
--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -255,7 +255,7 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         location?.setActivity(activity)
     }
 
-    fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?): Boolean {
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && requestCode == REQUEST_PERMISSIONS_REQUEST_CODE && permissions!!.size == 2 &&
                 permissions[0] == Manifest.permission.ACCESS_FINE_LOCATION && permissions[1] == Manifest.permission.ACCESS_BACKGROUND_LOCATION) {
             if (grantResults!![0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {

--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -255,7 +255,7 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         location?.setActivity(activity)
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?): Boolean {
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: Array?): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && requestCode == REQUEST_PERMISSIONS_REQUEST_CODE && permissions!!.size == 2 &&
                 permissions[0] == Manifest.permission.ACCESS_FINE_LOCATION && permissions[1] == Manifest.permission.ACCESS_BACKGROUND_LOCATION) {
             if (grantResults!![0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {

--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -255,7 +255,7 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         location?.setActivity(activity)
     }
 
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: Array?): Boolean {
+    fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && requestCode == REQUEST_PERMISSIONS_REQUEST_CODE && permissions!!.size == 2 &&
                 permissions[0] == Manifest.permission.ACCESS_FINE_LOCATION && permissions[1] == Manifest.permission.ACCESS_BACKGROUND_LOCATION) {
             if (grantResults!![0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
In this PR I added the fix to the issue above for the new flutter 3.0.0.