### PR TITLE
Disable showsBackgroundLocationIndicator

### DIFF
--- a/packages/location/ios/Classes/LocationPlugin.m
+++ b/packages/location/ios/Classes/LocationPlugin.m
@@ -58,6 +58,7 @@
         self.clLocationManager = [[CLLocationManager alloc] init];
         self.clLocationManager.delegate = self;
         self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
+        self.clLocationManager.showsBackgroundLocationIndicator = false;
     }
 }
 
@@ -101,7 +102,7 @@
                 self.clLocationManager.allowsBackgroundLocationUpdates = enable;
             }
             if (@available(iOS 11.0, *)) {
-                self.clLocationManager.showsBackgroundLocationIndicator = enable;
+                self.clLocationManager.showsBackgroundLocationIndicator = false;
             }
             result(enable ? @1 : @0);
         } else {


### PR DESCRIPTION
## Description

We don't want the background location indicator to be visible

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
