### PR TITLE
Update build.gradle

### DIFF
--- a/packages/location_android/android/build.gradle
+++ b/packages/location_android/android/build.gradle
@@ -47,6 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.android.gms:play-services-location:19.0.1"
+    implementation "com.google.android.gms:play-services-location:21.0.1"
     implementation "androidx.appcompat:appcompat:1.4.1"
 }


### PR DESCRIPTION
Fixed #802 IncompatibleClassChangeError

<!--
  Updated Google play services Library which was causing app crash in flutter 3.7.0
  
  
-->

 We were facing IncompatibleClassChangeError due to the old library and i have updated the version

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
