### PR TITLE
fix `changeNotificationOptions`

### DIFF
--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -59,7 +59,7 @@ class BackgroundNotification(
             ?.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
 
         return if (intent != null) {
-            PendingIntent.getActivity(context, 0, intent, 0)
+            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         } else {
             null
         }

--- a/packages/location_platform_interface/lib/src/method_channel_location.dart
+++ b/packages/location_platform_interface/lib/src/method_channel_location.dart
@@ -213,7 +213,7 @@ class MethodChannelLocation extends LocationPlatform {
     }
 
     final result = await _methodChannel!
-        .invokeMethod<Map<String, dynamic>?>('changeNotificationOptions', data);
+        .invokeMethod<Map<dynamic, dynamic>>('changeNotificationOptions', data);
 
     return result != null ? AndroidNotificationData.fromMap(result) : null;
   }


### PR DESCRIPTION
- fix #779 
- fix the following error when calling `changeNotificationOptions`
```
_TypeError (type '_Map<Object?, Object?>' is not a subtype of type 'Map<String, dynamic>?' in type cast)
```
in `MethodChannelLocation.changeNotificationOptions` (`location_platform_interface/src/method_channel_location.dart:215:20`)