### PR TITLE
Downgraded location_web dependency on js ^0.7.1 to js ^0.6.3 for comp…

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+
+- Downgraded location_web dependency on js ^0.7.1 to js ^0.6.3 for compatibility with firebase_core ^2.27.2
+
 ## 6.0.0
 
 - Bump Android Gradle Plugin from 7.4.2 to 8.3.1

--- a/packages/location/pubspec.yaml
+++ b/packages/location/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location
 description: Cross-platform plugin for easy access to device's location in real-time.
-version: 6.0.0
+version: 6.0.1
 homepage: https://docs.page/Lyokone/flutterlocation
 repository: https://github.com/Lyokone/flutterlocation
 issue_tracker: https://github.com/Lyokone/flutterlocation/issues

--- a/packages/location_web/CHANGELOG.md
+++ b/packages/location_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.0
+## 5.0.1
 
 - Downgraded location_web dependency on js ^0.7.1 to js ^0.6.3 for compatibility with firebase_core ^2.27.2
 

--- a/packages/location_web/CHANGELOG.md
+++ b/packages/location_web/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 5.0.0
 
+- Downgraded location_web dependency on js ^0.7.1 to js ^0.6.3 for compatibility with firebase_core ^2.27.2
+
+## 5.0.0
+
 - Bump minimum Dart version to 3.1, minimum Flutter version to 3.16
 - Bump dependencies
 

--- a/packages/location_web/CHANGELOG.md
+++ b/packages/location_web/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 5.0.1
-
-- Downgraded location_web dependency on js ^0.7.1 to js ^0.6.3 for compatibility with firebase_core ^2.27.2
-
 ## 5.0.0
 
 - Bump minimum Dart version to 3.1, minimum Flutter version to 3.16

--- a/packages/location_web/pubspec.yaml
+++ b/packages/location_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location_web
 description: The web implementation of the location plugin.
-version: 5.0.0
+version: 5.0.1
 homepage: https://github.com/Lyokone/flutterlocation
 repository: https://github.com/Lyokone/flutterlocation
 issue_tracker: https://github.com/Lyokone/flutterlocation/issues

--- a/packages/location_web/pubspec.yaml
+++ b/packages/location_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location_web
 description: The web implementation of the location plugin.
-version: 5.0.1
+version: 5.0.0
 homepage: https://github.com/Lyokone/flutterlocation
 repository: https://github.com/Lyokone/flutterlocation
 issue_tracker: https://github.com/Lyokone/flutterlocation/issues

--- a/packages/location_web/pubspec.yaml
+++ b/packages/location_web/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   http_parser: ^4.0.2
-  js: ^0.7.1
+  js: ^0.6.3
   location_platform_interface: ^4.0.0
 
 dev_dependencies:


### PR DESCRIPTION
#940 
Downgraded location_web dependency on js ^0.7.1 to js ^0.6.3 for compatibility with firebase_core ^2.27.2

✓ changeSettings should call the correct underlying instance
✓ isBackgroundModeEnabled should call the correct underlying instance
✓ enableBackgroundMode should call the correct underlying instance
✓ getLocation should call the correct underlying instance
✓ hasPermission should call the correct underlying instance
✓ requestPermission should call the correct underlying instance
✓ serviceEnabled should call the correct underlying instance
✓ requestService should call the correct underlying instance
✓ changeNotificationOptions should call the correct underlying instance
✓ onLocationChanged should receive values