### PR TITLE
Set foreground service type to `FOREGROUND_SERVICE_TYPE_LOCATION`

### DIFF
--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocationService.kt
@@ -11,6 +11,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
@@ -239,7 +240,19 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
             Log.d(TAG, "Start service in foreground mode.")
 
             val notification = backgroundNotification!!.build()
-            startForeground(ONGOING_NOTIFICATION_ID, notification)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    ONGOING_NOTIFICATION_ID,
+                    notification,
+                    FOREGROUND_SERVICE_TYPE_LOCATION
+                )
+            } else {
+                startForeground(
+                    ONGOING_NOTIFICATION_ID,
+                    notification
+                )
+            }
 
             isForeground = true
         }


### PR DESCRIPTION

This PR include foreground service type `FOREGROUND_SERVICE_TYPE_LOCATION` at runtime, [the Android SDK 34 requires it](https://developer.android.com/about/versions/14/changes/fgs-types-required).

> (...)
> Note: Beginning with SDK Version [android.os.Build.VERSION_CODES#UPSIDE_DOWN_CAKE](https://developer.android.com/reference/kotlin/android/os/Build.VERSION_CODES.html#UPSIDE_DOWN_CAKE:kotlin.Int), apps targeting SDK Version [android.os.Build.VERSION_CODES#UPSIDE_DOWN_CAKE](https://developer.android.com/reference/kotlin/android/os/Build.VERSION_CODES.html#UPSIDE_DOWN_CAKE:kotlin.Int) or higher are not allowed to start foreground services without specifying a valid foreground service type in the manifest attribute [android.R.attr#foregroundServiceType](https://developer.android.com/reference/kotlin/android/R.attr.html#foregroundServiceType:kotlin.Int). See Behavior changes: Apps targeting Android 14 for more details.
> 
> https://developer.android.com/reference/kotlin/android/app/Service#startforeground


Fix #924 and #954