### PR TITLE
Fix no location result from getLocation with "Precise Location" off on iOS 

### DIFF
--- a/packages/location/ios/Classes/LocationPlugin.m
+++ b/packages/location/ios/Classes/LocationPlugin.m
@@ -307,7 +307,17 @@
 
 - (void)locationManager:(CLLocationManager *)manager
      didUpdateLocations:(NSArray<CLLocation *> *)locations {
-  if (self.waitNextLocation > 0) {
+
+  // Check if location accuracy is reduced on iOS 14 and above
+  // This means precise location is disabled and only one location update will be sent
+  BOOL isReducedAccuracy = NO;
+  if (@available(iOS 14.0, *)) {
+    CLAccuracyAuthorization accuracy = [self.clLocationManager accuracyAuthorization];
+    isReducedAccuracy = (accuracy == CLAccuracyAuthorizationReducedAccuracy);
+  }
+
+  // Only use the guard if precise location is enabled
+  if (!isReducedAccuracy && self.waitNextLocation > 0) {
     self.waitNextLocation -= 1;
     return;
   }


### PR DESCRIPTION
When "precise location" is turned off on iOS, calling `getLocation` caused the app to wait indefinitely for a location response.

The root cause is that the guard condition in the code ignores the first two retrieved locations. However, with "precise location" turned off, only one location result seems to be obtained. This means the code never gets past the guard, resulting in no location being returned.

This fix bypasses the guard when "precise location" is off.

Fixes: #892, #815, #748

