### PR TITLE
Added requesting for coarse location in addition to precise location permission

### DIFF
--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -34,6 +34,7 @@ import com.google.android.gms.location.SettingsClient;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -345,7 +346,9 @@ public class FlutterLocation
             result.success(1);
             return;
         }
-        ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
+        ActivityCompat.requestPermissions(activity, new String[]{
+                        Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION
+                },
                 REQUEST_PERMISSIONS_REQUEST_CODE);
     }
 


### PR DESCRIPTION
See: https://developer.android.com/develop/sensors-and-location/location/permissions#approximate-request

> To handle this potential user behavior, don't request the ACCESS_FINE_LOCATION permission by itself. Instead, request both the ACCESS_FINE_LOCATION permission and the ACCESS_COARSE_LOCATION permission in a single runtime request. If you try to request only ACCESS_FINE_LOCATION, the system ignores the request on some releases of Android 12. If your app targets Android 12 or higher, the system logs the following error message in Logcat: [...]