### PR TITLE
Fixes #951 loosing location updates (consider pausesLocationUpdatesAutomatically)

### DIFF
--- a/packages/location/darwin/Classes/LocationPlugin.m
+++ b/packages/location/darwin/Classes/LocationPlugin.m
@@ -51,6 +51,7 @@
         self.clLocationManager = [[CLLocationManager alloc] init];
         self.clLocationManager.delegate = self;
         self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
+        self.clLocationManager.pausesLocationUpdatesAutomatically = NO;
     }
 }
 

--- a/packages/location/ios/Classes/LocationPlugin.m
+++ b/packages/location/ios/Classes/LocationPlugin.m
@@ -60,6 +60,7 @@
     self.clLocationManager = [[CLLocationManager alloc] init];
     self.clLocationManager.delegate = self;
     self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
+    self.clLocationManager.pausesLocationUpdatesAutomatically = NO;
   }
 }
 

--- a/packages/location/macos/Classes/LocationPlugin.m
+++ b/packages/location/macos/Classes/LocationPlugin.m
@@ -51,6 +51,7 @@
         self.clLocationManager = [[CLLocationManager alloc] init];
         self.clLocationManager.delegate = self;
         self.clLocationManager.desiredAccuracy = kCLLocationAccuracyBest;
+        self.clLocationManager.pausesLocationUpdatesAutomatically = NO;
     }
 }
 


### PR DESCRIPTION
Fixes #951 loosing location updates (consider pausesLocationUpdatesAutomatically)

Straight fix to avoid location updates after some indeterministic time.
See: [https://developer.apple.com/documentation/corelocation/cllocationmanager/pauseslocationupdatesautomatically]
