### PR TITLE
Fix web dependencies typo

### DIFF
--- a/packages/location_web/pubspec.yaml
+++ b/packages/location_web/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   http_parser: ^4.0.2
   js: ^0.6.3
   location_platform_interface: ^5.0.0
-  web: ">=^0.5.1 <2.0.0"
+  web: ">=0.5.1 <2.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
There is a typo on pubspec.yaml from location_web.
Could you merge + release the new version for efficient web 0.5.1+ support please ?

Thanks a lot.