### PR TITLE
Fix deprecation warnings

### DIFF
--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -29,6 +29,7 @@ import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.location.LocationSettingsRequest;
 import com.google.android.gms.location.LocationSettingsStatusCodes;
+import com.google.android.gms.location.Priority;
 import com.google.android.gms.location.SettingsClient;
 
 import io.flutter.plugin.common.EventChannel.EventSink;
@@ -64,7 +65,7 @@ public class FlutterLocation
     // Parameters of the request
     private long updateIntervalMilliseconds = 5000;
     private long fastestUpdateIntervalMilliseconds = updateIntervalMilliseconds / 2;
-    private Integer locationAccuracy = LocationRequest.PRIORITY_HIGH_ACCURACY;
+    private Integer locationAccuracy = Priority.PRIORITY_HIGH_ACCURACY;
     private float distanceFilter = 0f;
 
     public EventSink events;
@@ -82,12 +83,12 @@ public class FlutterLocation
 
     public SparseArray<Integer> mapFlutterAccuracy = new SparseArray<Integer>() {
         {
-            put(0, LocationRequest.PRIORITY_NO_POWER);
-            put(1, LocationRequest.PRIORITY_LOW_POWER);
-            put(2, LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
-            put(3, LocationRequest.PRIORITY_HIGH_ACCURACY);
-            put(4, LocationRequest.PRIORITY_HIGH_ACCURACY);
-            put(5, LocationRequest.PRIORITY_LOW_POWER);
+            put(0, Priority.PRIORITY_PASSIVE);
+            put(1, Priority.PRIORITY_LOW_POWER);
+            put(2, Priority.PRIORITY_BALANCED_POWER_ACCURACY);
+            put(3, Priority.PRIORITY_HIGH_ACCURACY);
+            put(4, Priority.PRIORITY_HIGH_ACCURACY);
+            put(5, Priority.PRIORITY_LOW_POWER);
         }
     };
 
@@ -215,6 +216,7 @@ public class FlutterLocation
     /**
      * Creates a callback for receiving location events.
      */
+    @SuppressWarnings("deprecation")
     private void createLocationCallback() {
         if (mLocationCallback != null) {
             mFusedLocationClient.removeLocationUpdates(mLocationCallback);
@@ -243,7 +245,13 @@ public class FlutterLocation
                     loc.put("satelliteNumber", location.getExtras().getInt("satellites"));
                 }
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    loc.put("elapsedRealtimeNanos", (double) location.getElapsedRealtimeNanos());
+
+                    if (location.isMock()) {
+                        loc.put("isMock", (double) 1);
+                    }
+                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
                     loc.put("elapsedRealtimeNanos", (double) location.getElapsedRealtimeNanos());
 
                     if (location.isFromMockProvider()) {
@@ -303,12 +311,16 @@ public class FlutterLocation
      * Sets up the location request. Android has two location request settings:
      */
     private void createLocationRequest() {
-        mLocationRequest = LocationRequest.create();
+        // API nova do FusedLocationProvider (sem métodos deprecados)
+        final int priority = (this.locationAccuracy != null)
+                ? this.locationAccuracy
+                : Priority.PRIORITY_HIGH_ACCURACY;
 
-        mLocationRequest.setInterval(this.updateIntervalMilliseconds);
-        mLocationRequest.setFastestInterval(this.fastestUpdateIntervalMilliseconds);
-        mLocationRequest.setPriority(this.locationAccuracy);
-        mLocationRequest.setSmallestDisplacement(this.distanceFilter);
+        LocationRequest.Builder builder = new LocationRequest.Builder(priority, this.updateIntervalMilliseconds)
+                .setMinUpdateIntervalMillis(this.fastestUpdateIntervalMilliseconds)
+                .setMinUpdateDistanceMeters(this.distanceFilter);
+
+        mLocationRequest = builder.build();
     }
 
     /**

--- a/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
+++ b/packages/location/android/src/main/java/com/lyokone/location/FlutterLocation.java
@@ -311,7 +311,6 @@ public class FlutterLocation
      * Sets up the location request. Android has two location request settings:
      */
     private void createLocationRequest() {
-        // API nova do FusedLocationProvider (sem métodos deprecados)
         final int priority = (this.locationAccuracy != null)
                 ? this.locationAccuracy
                 : Priority.PRIORITY_HIGH_ACCURACY;

--- a/packages/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
+++ b/packages/location/android/src/main/java/com/lyokone/location/MethodCallHandlerImpl.java
@@ -99,9 +99,14 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
     private void onChangeSettings(MethodCall call, Result result) {
         try {
             final Integer locationAccuracy = location.mapFlutterAccuracy.get((Integer) call.argument("accuracy"));
-            final Long updateIntervalMilliseconds = new Long((int) call.argument("interval"));
-            final Long fastestUpdateIntervalMilliseconds = updateIntervalMilliseconds / 2;
-            final Float distanceFilter = new Float((double) call.argument("distanceFilter"));
+
+            final Number interval = (Number) call.argument("interval");
+            final Long updateIntervalMilliseconds = Long.valueOf(interval != null ? interval.longValue() : 0L);
+
+            final Long fastestUpdateIntervalMilliseconds = Long.valueOf(updateIntervalMilliseconds / 2);
+
+            final Number distance = (Number) call.argument("distanceFilter");
+            final Float distanceFilter = Float.valueOf(distance != null ? distance.floatValue() : 0f);
 
             location.changeSettings(locationAccuracy, updateIntervalMilliseconds, fastestUpdateIntervalMilliseconds,
                     distanceFilter);


### PR DESCRIPTION
This PR resolves #1035


Migrated from deprecated `LocationRequest` to `Priority`
Priority doesn't have a PRIORITY_NO_POWER property, according to its [documentation](https://developers.google.com/android/reference/com/google/android/gms/location/Priority) we should use PRIORITY_PASSIVE

`LocationRequest.PRIORITY_NO_POWER` -> `Priority.PRIORITY_PASSIVE`

---

On SDK 31+ `location.isFromMockProvider()` is deprecated, but older versions of android still uses it, so we have to annotate the method with `@SuppressWarnings("deprecation")`
If the project is running sdk 31+ we use `location.isMock()`, otherwise we fallback to `location.isFromMockProvider()`

---

For the `LocationRequest.create()` we have to use the new builder `LocationRequest.Builder()`. The parameters are passed to the builder, and not the mLocationRequest directly

---

The `new Long()` and `new Float()` were migrated to `Number`, and manipulated so we could have a proper Long and Float values



If I missed something, please point it out so I can fix it