### PR TITLE
fix(darwin): move locationServicesEnabled off the main thread

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+<!-- Not yet published to pub.dev. Accumulate fixes here; assign a version
+     number when we cut the next release. -->
+
+### 🍎 iOS & macOS
+
+- Moved `CLLocationManager.locationServicesEnabled()` off the main thread. Apple
+  warns that this call can block the caller while location services start up;
+  invoking it on the main thread triggered the "UI unresponsiveness" runtime
+  warning and could hang the app (#782, #789, #909, #1004, #1027). It now runs on
+  a background queue with the result delivered back on the main thread, so
+  `getLocation`, `serviceEnabled`, `requestService` and `changeSettings` no
+  longer stall the UI.
+
 ## 9.0.0
 
 A major maintenance release that modernises every platform and adds desktop

--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -76,42 +76,61 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
         }
     }
 
+    // MARK: - Location services
+
+    /// `CLLocationManager.locationServicesEnabled()` can block the calling
+    /// thread while location services start up. Apple warns against calling it
+    /// on the main thread — doing so triggers the "UI unresponsiveness" runtime
+    /// warning and can hang the app (#782, #789, #909, #1004, #1027). Run it on
+    /// a background queue and deliver the answer back on the main thread, where
+    /// the `CLLocationManager` instance and the Flutter result must be used.
+    private func locationServicesEnabled(_ completion: @escaping (Bool) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let enabled = CLLocationManager.locationServicesEnabled()
+            DispatchQueue.main.async {
+                completion(enabled)
+            }
+        }
+    }
+
     // MARK: - Method handlers
 
-    private func onChangeSettings(_ call: FlutterMethodCall, result: FlutterResult) {
-        guard CLLocationManager.locationServicesEnabled() else { return }
-        guard
-            let manager = clLocationManager,
-            let args = call.arguments as? [String: Any]
-        else {
-            result(FlutterError(code: "CHANGE_SETTINGS_ERROR", message: "Invalid arguments", details: nil))
-            return
-        }
+    private func onChangeSettings(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        locationServicesEnabled { [weak self] enabled in
+            guard let self, enabled else { return }
+            guard
+                let manager = self.clLocationManager,
+                let args = call.arguments as? [String: Any]
+            else {
+                result(FlutterError(code: "CHANGE_SETTINGS_ERROR", message: "Invalid arguments", details: nil))
+                return
+            }
 
-        var reducedAccuracy = kCLLocationAccuracyHundredMeters
-        if #available(iOS 14, macOS 11, *) {
-            reducedAccuracy = kCLLocationAccuracyReduced
-        }
-        let accuracyMap: [Int: CLLocationAccuracy] = [
-            0: kCLLocationAccuracyKilometer,
-            1: kCLLocationAccuracyHundredMeters,
-            2: kCLLocationAccuracyNearestTenMeters,
-            3: kCLLocationAccuracyBest,
-            4: kCLLocationAccuracyBestForNavigation,
-            5: reducedAccuracy,
-        ]
+            var reducedAccuracy = kCLLocationAccuracyHundredMeters
+            if #available(iOS 14, macOS 11, *) {
+                reducedAccuracy = kCLLocationAccuracyReduced
+            }
+            let accuracyMap: [Int: CLLocationAccuracy] = [
+                0: kCLLocationAccuracyKilometer,
+                1: kCLLocationAccuracyHundredMeters,
+                2: kCLLocationAccuracyNearestTenMeters,
+                3: kCLLocationAccuracyBest,
+                4: kCLLocationAccuracyBestForNavigation,
+                5: reducedAccuracy,
+            ]
 
-        if let accuracy = args["accuracy"] as? Int, let mapped = accuracyMap[accuracy] {
-            manager.desiredAccuracy = mapped
-        }
+            if let accuracy = args["accuracy"] as? Int, let mapped = accuracyMap[accuracy] {
+                manager.desiredAccuracy = mapped
+            }
 
-        let distanceFilter = args["distanceFilter"] as? Double ?? 0
-        manager.distanceFilter = distanceFilter == 0 ? kCLDistanceFilterNone : distanceFilter
+            let distanceFilter = args["distanceFilter"] as? Double ?? 0
+            manager.distanceFilter = distanceFilter == 0 ? kCLDistanceFilterNone : distanceFilter
 
-        if let pauses = args["pausesLocationUpdatesAutomatically"] as? Bool {
-            manager.pausesLocationUpdatesAutomatically = pauses
+            if let pauses = args["pausesLocationUpdatesAutomatically"] as? Bool {
+                manager.pausesLocationUpdatesAutomatically = pauses
+            }
+            result(1)
         }
-        result(1)
     }
 
     private func onIsBackgroundModeEnabled(result: FlutterResult) {
@@ -138,31 +157,34 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     }
 
     private func onGetLocation(result: @escaping FlutterResult) {
-        guard CLLocationManager.locationServicesEnabled() else {
-            result(FlutterError(
-                code: "SERVICE_STATUS_DISABLED",
-                message: "Failed to get location. Location services disabled",
-                details: nil,
-            ))
-            return
-        }
-        if currentAuthorizationStatus == .denied {
-            result(FlutterError(
-                code: "PERMISSION_DENIED",
-                message: "The user explicitly denied the use of location services for this app or "
-                    + "location services are currently disabled in Settings.",
-                details: nil,
-            ))
-            return
-        }
+        locationServicesEnabled { [weak self] enabled in
+            guard let self else { return }
+            guard enabled else {
+                result(FlutterError(
+                    code: "SERVICE_STATUS_DISABLED",
+                    message: "Failed to get location. Location services disabled",
+                    details: nil,
+                ))
+                return
+            }
+            if self.currentAuthorizationStatus == .denied {
+                result(FlutterError(
+                    code: "PERMISSION_DENIED",
+                    message: "The user explicitly denied the use of location services for this app or "
+                        + "location services are currently disabled in Settings.",
+                    details: nil,
+                ))
+                return
+            }
 
-        flutterResult = result
-        locationWanted = true
+            self.flutterResult = result
+            self.locationWanted = true
 
-        if isPermissionGranted {
-            clLocationManager?.startUpdatingLocation()
-        } else {
-            requestPermission()
+            if self.isPermissionGranted {
+                self.clLocationManager?.startUpdatingLocation()
+            } else {
+                self.requestPermission()
+            }
         }
     }
 
@@ -186,37 +208,41 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
         }
     }
 
-    private func onServiceEnabled(result: FlutterResult) {
-        result(CLLocationManager.locationServicesEnabled() ? 1 : 0)
+    private func onServiceEnabled(result: @escaping FlutterResult) {
+        locationServicesEnabled { enabled in
+            result(enabled ? 1 : 0)
+        }
     }
 
-    private func onRequestService(result: FlutterResult) {
-        if CLLocationManager.locationServicesEnabled() {
-            result(1)
-            return
-        }
-        #if os(macOS)
-        let alert = NSAlert()
-        alert.messageText = "Location is Disabled"
-        alert.informativeText = "To use location, go to your System Settings > Privacy & Security > "
-            + "Location Services."
-        alert.addButton(withTitle: "Open")
-        alert.addButton(withTitle: "Cancel")
-        if let window = NSApplication.shared.mainWindow {
-            alert.beginSheetModal(for: window) { response in
-                if response == .alertFirstButtonReturn,
-                   let url = URL(
-                       string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices") {
-                    NSWorkspace.shared.open(url)
+    private func onRequestService(result: @escaping FlutterResult) {
+        locationServicesEnabled { enabled in
+            if enabled {
+                result(1)
+                return
+            }
+            #if os(macOS)
+            let alert = NSAlert()
+            alert.messageText = "Location is Disabled"
+            alert.informativeText = "To use location, go to your System Settings > Privacy & Security > "
+                + "Location Services."
+            alert.addButton(withTitle: "Open")
+            alert.addButton(withTitle: "Cancel")
+            if let window = NSApplication.shared.mainWindow {
+                alert.beginSheetModal(for: window) { response in
+                    if response == .alertFirstButtonReturn,
+                       let url = URL(
+                           string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices") {
+                        NSWorkspace.shared.open(url)
+                    }
                 }
             }
+            #elseif os(iOS)
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(url)
+            }
+            #endif
+            result(0)
         }
-        #elseif os(iOS)
-        if let url = URL(string: UIApplication.openSettingsURLString) {
-            UIApplication.shared.open(url)
-        }
-        #endif
-        result(0)
     }
 
     // MARK: - Permissions


### PR DESCRIPTION
## Problem

`CLLocationManager.locationServicesEnabled()` was called synchronously on the main thread in four handlers. Apple documents that this call can block the caller while location services spin up — it's what triggers the **"This method can cause UI unresponsiveness if invoked on the main thread"** CoreLocation warning and, in the worst case, hangs the app.

## Fix

- Added a `locationServicesEnabled(_:)` helper that runs the check on a background queue (`DispatchQueue.global(qos: .userInitiated)`) and delivers the result back on `DispatchQueue.main`, where the `CLLocationManager` instance and the `FlutterResult` must be used.
- Routed all four call sites through it: `onGetLocation`, `onServiceEnabled`, `onRequestService`, `onChangeSettings` (their `result` params are now `@escaping`).

The deprecated `CLLocationManager.authorizationStatus()` iOS <14 fallback is left as-is — Apple's blocking warning is specific to `locationServicesEnabled()`, and iOS 14+/macOS 11+ already use the non-blocking instance property.

## Fixed issues

These reports all quote the literal main-thread "UI unresponsiveness" CoreLocation warning that this change removes:

Fixes #782, fixes #789, fixes #909, fixes #1004, fixes #1027

## Possibly related (not auto-closed — need confirmation on a build with this fix)

These are iOS "getLocation never completes / hangs" reports with no explicit warning logged; they may share this root cause but weren't individually verified: #798, #955, #1005, #660, #824.

Not included (confirmed a different root cause): the Android reports #608, #708, #759, #869, #885, #899, #912, #949, #995, the iOS-simulator "Custom Location" quirk #657 / #1013, the stale-location guard #916, and the "Allow once" auth-flow report #621.

## Changelog / release

Recorded under a new **`## Unreleased`** section in `CHANGELOG.md` rather than cutting a version, so it accumulates with other post-9.0.0 fixes and we don't publish a separate version for each. No `pubspec.yaml` bump — intentionally **not** for publication yet.

## Verification

`flutter build ios --simulator --no-codesign` → builds successfully. CI: all six jobs (Android, Flutter, Linux, Windows, iOS, macOS) green.