### PR TITLE
feat(darwin): add Apple privacy manifest

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -12,6 +12,9 @@
   a background queue with the result delivered back on the main thread, so
   `getLocation`, `serviceEnabled`, `requestService` and `changeSettings` no
   longer stall the UI.
+- Added an Apple **privacy manifest** (`PrivacyInfo.xcprivacy`) for iOS and macOS,
+  declaring no tracking, no collected data and no required-reason API use, as
+  required for App Store submission (#947).
 
 ## 9.0.0
 

--- a/packages/location/darwin/location.podspec
+++ b/packages/location/darwin/location.podspec
@@ -13,6 +13,7 @@ Cross-platform plugin for easy access to the device location in real time.
   s.author           = { 'Lyokone' => 'https://github.com/Lyokone/flutterlocation' }
   s.source           = { :path => '.' }
   s.source_files     = 'location/Sources/location/**/*.swift'
+  s.resource_bundles = { 'location_privacy' => ['location/Sources/location/PrivacyInfo.xcprivacy'] }
 
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'

--- a/packages/location/darwin/location/Package.swift
+++ b/packages/location/darwin/location/Package.swift
@@ -17,7 +17,10 @@ let package = Package(
     targets: [
         .target(
             name: "location",
-            dependencies: []
+            dependencies: [],
+            resources: [
+                .process("PrivacyInfo.xcprivacy"),
+            ]
         ),
     ]
 )

--- a/packages/location/darwin/location/Sources/location/PrivacyInfo.xcprivacy
+++ b/packages/location/darwin/location/Sources/location/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## What

Adds `PrivacyInfo.xcprivacy` for iOS and macOS, wired into **both** build systems so it ships regardless of how the plugin is consumed:
- CocoaPods — `s.resource_bundles` in `location.podspec`
- Swift Package Manager — `resources: [.process(...)]` in `Package.swift`

Closes #947.

## What it declares

The plugin surfaces CoreLocation to the host app but does **not** track users, transmit data off-device, or use any [required-reason APIs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api) (that list is UserDefaults / file-timestamp / boot-time / disk-space / keyboards — CoreLocation isn't on it). So the manifest declares:

| Key | Value |
|---|---|
| `NSPrivacyTracking` | `false` |
| `NSPrivacyTrackingDomains` | empty |
| `NSPrivacyCollectedDataTypes` | empty |
| `NSPrivacyAccessedAPITypes` | empty |

This mirrors the App Store-reviewed [`geolocator_apple` manifest](https://github.com/Baseflow/flutter-geolocator/blob/main/geolocator_apple/darwin/geolocator_apple/Sources/geolocator_apple/PrivacyInfo.xcprivacy) — the closest comparable plugin — which ships the same no-collection form. The host app remains responsible for declaring how *it* uses location in its own app-level manifest.

## Verification

- `plutil -lint` → OK
- `swift package describe` lists the manifest as a target resource
- `flutter build ios --simulator` → builds; manifest is bundled at `location_location.bundle/PrivacyInfo.xcprivacy` with all four keys intact (`plutil -p` confirmed)

## Release

Logged under the existing `## Unreleased` CHANGELOG section — no version bump, not for publication yet.