### PR TITLE
fix(darwin): stop getLocation hanging on sparse location updates

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -15,6 +15,11 @@
 - Added an Apple **privacy manifest** (`PrivacyInfo.xcprivacy`) for iOS and macOS,
   declaring no tracking, no collected data and no required-reason API use, as
   required for App Store submission (#947).
+- Fixed `getLocation()` hanging forever when Core Location delivered fewer than
+  three updates — e.g. a static iOS-simulator "Custom Location" or a sparse first
+  fix. The stale-location guard swallowed the first two updates by count; it now
+  skips fixes by age instead, so the first fresh update always resolves the call
+  (#798, #955, #1005, #660, #824, #657, #1013).
 
 ## 9.0.0
 

--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -19,8 +19,10 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     private var hasInit = false
     private var applicationHasLocationBackgroundMode = false
 
-    // Needed to prevent instant firing of the previously known location.
-    private var waitNextLocation = 2
+    // CoreLocation delivers a cached fix immediately when updates start; fixes
+    // older than this (in seconds) are treated as stale and skipped. See
+    // locationManager(_:didUpdateLocations:).
+    private let staleLocationThreshold: TimeInterval = 15
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         #if os(iOS)
@@ -325,17 +327,19 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     // MARK: - CLLocationManagerDelegate
 
     public func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        // With reduced accuracy (precise location off) only a single update is
-        // delivered, so the stale-location guard must not swallow it (#984).
-        var isReducedAccuracy = false
-        if #available(iOS 14.0, macOS 11.0, *) {
-            isReducedAccuracy = clLocationManager?.accuracyAuthorization == .reducedAccuracy
-        }
-        if !isReducedAccuracy, waitNextLocation > 0 {
-            waitNextLocation -= 1
+        guard let location = locations.last else { return }
+
+        // CoreLocation delivers a cached "last known" fix immediately when
+        // updates start. Skip clearly-stale fixes so callers get a current
+        // position — but key this off the fix age rather than swallowing a
+        // fixed number of updates. The old counter dropped the first two
+        // updates, so a one-shot getLocation() never completed when fewer than
+        // three arrived: reduced accuracy delivers a single update (#984) and a
+        // static iOS-simulator location emits only a couple (#657, #955, #1005,
+        // #1013), leaving the Dart Future hanging forever.
+        if abs(location.timestamp.timeIntervalSinceNow) > staleLocationThreshold {
             return
         }
-        guard let location = locations.last else { return }
 
         let timeInMilliseconds = location.timestamp.timeIntervalSince1970 * 1000
         let coordinates: [String: Any] = [
@@ -359,7 +363,6 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
             flutterEventSink?(coordinates)
         } else {
             clLocationManager?.stopUpdatingLocation()
-            waitNextLocation = 2
         }
     }
 


### PR DESCRIPTION
## The second root cause behind the iOS "getLocation never completes" cluster

The main-thread PR (#1050) fixed the `locationServicesEnabled` hang. This fixes a **separate** root cause with the same symptom.

`didUpdateLocations` skipped the cached "last known" fix by **counting**: `waitNextLocation = 2` dropped the first two updates, so a one-shot `getLocation()` only resolved on the **third**. When Core Location delivers fewer than three updates, the Dart Future hangs forever with no error:

- a **static iOS-simulator "Custom Location"** emits only a couple of updates (#657, #1013, #955, #1005),
- a sparse **first fix** on real launch (#798),
- reduced accuracy emits a *single* update — already special-cased for #984, which was the tell that a fixed count is the wrong mechanism.

## Fix

Skip stale fixes by **age** instead of by count — deliver the first update whose timestamp is recent. This resolves `getLocation()` on the first fresh fix (never hangs) while still ignoring the instantly-delivered cached location, and it unifies the full-accuracy and reduced-accuracy paths (the #984 special-case is no longer needed).

```swift
if abs(location.timestamp.timeIntervalSinceNow) > staleLocationThreshold { return }
```

## Runtime verification (before/after)

Drove `getLocation()` on a booted iOS simulator with a **static Custom Location** (`simctl location set`) and permission granted, via a throwaway integration test asserting completion within 20s:

| Code | Result |
|---|---|
| **Old** (count-based guard) | `getLocation() did not complete within 20s (hang)` → ❌ fails |
| **New** (age-based skip) | `VERIFY getLocation -> 37.3349, -122.009` → ✅ passes |

Same repro condition, opposite outcome — confirms both the root cause and the fix. (The test itself is not committed; location-dependent tests are too flaky for CI.) iOS example also `flutter build`s clean.

## Closes

Fixes #798, fixes #955, fixes #1005, fixes #657, fixes #1013

## Not auto-closed (possibly related, unconfirmed)

`#824` (platform unstated, may be Android) and `#660` (symptom is *returns null*, not a hang — likely a different cause).

## Release

Logged under `## Unreleased` — no version bump, not for publication yet.