### PR TITLE
docs: correct the docs site to match the shipped API

### DIFF
--- a/docs/features/get-location.mdx
+++ b/docs/features/get-location.mdx
@@ -8,34 +8,33 @@ description: How to get your user's location
 To get the location of the user, you can simply use
 
 ```dart
-Future<LocationData> getLocation({LocationSettings? settings})
+Future<LocationData> getLocation()
 ```
-
-To see all the settings, see [the settings](/features/settings) page.
 
 By default, the call will try to **request permission** if needed, **activate GPS** and return the location without anything needed from your part.
 If something goes wrong the call will throw.
 
-If you have set global settings, it will use those settings instead of the default ones.
-
-If you are currently listening for location with `onLocationChanged`, it will use the settings from this call.
-
-If you call getLocation multiples times, the requests will be queued and they will receive the same location when available.
+The accuracy, interval and distance filter used for the request come from the
+global settings. See [the settings](/features/settings) page to change them with
+`changeSettings`.
 
 ## Examples
 
 ### Getting location
 
 ```dart
-final location = await getLocation();
-print("Location: ${location.latitude}, ${location.longitude}");
+final location = Location();
+final locationData = await location.getLocation();
+print("Location: ${locationData.latitude}, ${locationData.longitude}");
 ```
 
 ### With custom settings
 
+Configure the request beforehand with `changeSettings`:
+
 ```dart
-final location = await getLocation(
-    settings: LocationSettings(ignoreLastKnownPosition: true),
-);
-print("Location: ${location.latitude}, ${location.longitude}");
+final location = Location();
+await location.changeSettings(accuracy: LocationAccuracy.high);
+final locationData = await location.getLocation();
+print("Location: ${locationData.latitude}, ${locationData.longitude}");
 ```

--- a/docs/features/listen-location.mdx
+++ b/docs/features/listen-location.mdx
@@ -8,37 +8,52 @@ description: How to listen to your user's location
 To listen to the location of the user, you can simply use
 
 ```dart
-Stream<LocationData> onLocationChanged({bool inBackground = false})
+Stream<LocationData> get onLocationChanged
 ```
 
-The stream will use the global settings for location tracking.
-You can set the settings with [`setLocationSettings`](/features/settings).
+The stream uses the global settings for location tracking.
+You can change them with [`changeSettings`](/features/settings).
 
-If you change settings while listening to the location, the stream will be updated with the new settings (you can only have onn global settings active at the same time).
+If you change settings while listening to the location, the stream will use the new settings without being closed (you can only have one set of global settings active at the same time).
 
 Don't forget to **cancel the stream** when you don't need it anymore. Otherwise the location will keep being tracked.
 
-If you set the boolean `inBackground` to true, you will have receive background location notifications. It works only if the app is not killed.
-On Android, listening to background location will trigger a notification that you can control with [`updateBackgroundNotification`](/features/notification).
+To receive location updates while the app is in the background, enable background mode with `enableBackgroundMode(enable: true)` first.
+On Android, background location triggers a notification that you can control with [`changeNotificationOptions`](/features/notification).
 
 ## Examples
+
+### Listening to location
+
+```dart
+final location = Location();
+final subscription = location.onLocationChanged
+    .listen((LocationData currentLocation) {
+        print('Location: ${currentLocation.latitude}, ${currentLocation.longitude}');
+    });
+
+// ...
+
+subscription.cancel();
+```
 
 ### Listening to location in the background
 
 The notification will only appear on Android
 
 ```dart
-_locationSubscription = onLocationChanged(inBackground: _inBackground)
+final location = Location();
+await location.enableBackgroundMode(enable: true);
+final subscription = location.onLocationChanged
     .listen((LocationData currentLocation) async {
-        await updateBackgroundNotification(
+        await location.changeNotificationOptions(
             subtitle:
                 'Location: ${currentLocation.latitude}, ${currentLocation.longitude}',
             onTapBringToFront: true,
         );
-    }
-);
+    });
 
-...
+// ...
 
-_locationSubscription?.cancel();
+subscription.cancel();
 ```

--- a/docs/features/notification.mdx
+++ b/docs/features/notification.mdx
@@ -33,7 +33,7 @@ final location = Location();
 location.enableBackgroundMode(enable: true);
 _locationSubscription = location.onLocationChanged
     .listen((LocationData currentLocation) async {
-        await location.changeBackgroundOptions(
+        await location.changeNotificationOptions(
             subtitle:
                 'Location: ${currentLocation.latitude}, ${currentLocation.longitude}',
             onTapBringToFront: true,

--- a/docs/features/permissions.mdx
+++ b/docs/features/permissions.mdx
@@ -8,36 +8,37 @@ description: Manually handle permissions
 The package has been designed so you don't need to handle permissions manually.
 The first call to `getLocation` or `onLocationChanged` will automatically request the permissions.
 
-If you need to handle the permissions manually you can still use the `requestPermissions` method.
+If you need to handle the permissions manually you can still use the `requestPermission` method.
 
 ## Get Permission Status
 
 ```dart
-Future<PermissionStatus> getPermissionStatus()
+Future<PermissionStatus> hasPermission()
 ```
 
-If the status is `PermissionStatus.authorizedAlways` or `PermissionStatus.authorizedWhenInUse` you can use the `getLocation` method.
+If the status is `PermissionStatus.granted` or `PermissionStatus.grantedLimited` you can use the `getLocation` method.
 
-If the status is `PermissionStatus.notDetermined` you can use the `requestPermissions` method to get the permission.
+If the status is `PermissionStatus.denied` you can use the `requestPermission` method to ask the user for the permission.
 
-If the status is `PermissionStatus.denied` your user will not be shown the permission popup the next time. The next location request will probably fail.
+If the status is `PermissionStatus.deniedForever` your user will not be shown the permission popup the next time. The next location request will probably fail.
 You should request the user to manually change the settings of the app.
 
-## Request Permissions
+## Request Permission
 
 ```dart
 Future<PermissionStatus> requestPermission()
 ```
 
 A dialog will be shown to the user if the location has not been granted yet.
-If a reduced precision permission has been given, the user will be asked to grant the precise permission.
+If a reduced precision permission has been given (`PermissionStatus.grantedLimited`), the user will be asked to grant the precise permission.
 
 ## Examples
 
 ### Getting permission status
 
 ```dart
-final permission = await getPermissionStatus();
+final location = Location();
+final permission = await location.hasPermission();
 if (permission == PermissionStatus.denied) {
     print("The user will not allow you to use the location");
 }

--- a/docs/features/services.mdx
+++ b/docs/features/services.mdx
@@ -5,20 +5,37 @@ description: Check service status
 
 # Services
 
-Services refers to the options available to you in order to get the location of your user.
+The location service is the system-level switch that has to be on for any app to
+access the device's location.
 
-On **Android** you can have the status of the GPS and Network services.
-The Network service is often less precise.
-
-On **iOS** both the GPS and the Network service are available but cannot be requested individually. Either the Location Service is activated or not.
+Check whether it is currently enabled:
 
 ```dart
-Future<bool> isGPSEnabled()
+Future<bool> serviceEnabled()
 ```
+
+Request the user to enable it:
 
 ```dart
-Future<bool> isNetworkEnabled()
+Future<bool> requestService()
 ```
 
-If the service are disabled, you can make a call to `getLocation` or `onLocationChanged`.
-The call will automatically try to activate the required location service depending on the precision request for the location.
+`getLocation` and `onLocationChanged` also try to activate the service
+automatically, so calling these manually is only needed if you want to check or
+prompt for the service before requesting a location.
+
+## Examples
+
+### Ensuring the service is enabled
+
+```dart
+final location = Location();
+var enabled = await location.serviceEnabled();
+if (!enabled) {
+    enabled = await location.requestService();
+    if (!enabled) {
+        // The user did not enable the location service.
+        return;
+    }
+}
+```

--- a/docs/features/settings.mdx
+++ b/docs/features/settings.mdx
@@ -5,94 +5,38 @@ description: How to change your location settings
 
 # Settings
 
-With Location, there is two ways to change your location settings.
-
-## Individual Requests
-
-You change settings for an individual getLocation request like described in the [`getLocation`](/features/get-location) section.
-
-## Global Settings
+Location uses a single set of global settings, applied with `changeSettings`.
+These settings are shared by both `getLocation` and `onLocationChanged`.
 
 ```dart
-Future<void> setLocationSettings({
-  /// If set to true, the user will be prompted to grant permission to use location
-  /// if not already granted.
-  bool askForPermission = true,
+Future<bool> changeSettings({
+  /// The accuracy of the location request. One of the `LocationAccuracy`
+  /// values: powerSave, low, balanced, high, navigation or reduced.
+  LocationAccuracy? accuracy = LocationAccuracy.high,
 
-  /// The message to display to the user when asking for permission to use location.
-  /// Only valid on Android.
-  /// For iOS, you have to change the permission in the Info.plist file.
-  String rationaleMessageForPermissionRequest =
-      'The app needs to access your location',
+  /// The interval between location updates, in milliseconds.
+  /// Not used on web.
+  int? interval = 1000,
 
-  /// The message to display to the user when asking for permission to use GPS.
-  /// Only valid on Android.
-  String rationaleMessageForGPSRequest =
-      'The app needs to access your location',
+  /// The smallest distance, in meters, the device has to move before a new
+  /// update is emitted. Not used on web.
+  double? distanceFilter = 0,
 
-  /// If set to true, the app will use Google Play Services to request location.
-  /// If not available on the device, the app will fallback to GPS.
-  /// Only valid on Android.
-  bool useGooglePlayServices = true,
-
-  /// If set to true, the app will request Google Play Services to request location.
-  /// If not available on the device, the app will fallback to GPS.
-  bool askForGooglePlayServices = false,
-
-  /// If set to true, the app will request GPS to request location.
-  /// Only valid on Android.
-  bool askForGPS = true,
-
-  /// If set to true, the app will fallback to GPS if Google Play Services is not
-  /// available on the device.
-  /// Only valid on Android.
-  bool fallbackToGPS = true,
-
-  /// If set to true, the app will ignore the last known position
-  /// and request a fresh one
-  bool ignoreLastKnownPosition = true,
-
-  /// The duration of the location request.
-  /// Only valid on Android.
-  double? expirationDuration,
-
-  /// The expiration time of the location request.
-  /// Only valid on Android.
-  double? expirationTime,
-
-  /// The fastest interval between location updates.
-  /// In milliseconds.
-  /// Only valid on Android.
-  double fastestInterval = 500,
-
-  /// The interval between location updates.
-  /// In milliseconds.
-  double interval = 1000,
-
-  /// The maximum amount of time the app will wait for a location.
-  /// In milliseconds.
-  double? maxWaitTime,
-
-  /// The number of location updates to request.
-  /// Only valid on Android.
-  int? numUpdates,
-
-  /// The accuracy of the location request.
-  LocationAccuracy accuracy = LocationAccuracy.high,
-
-  /// The smallest displacement between location updates.
-  double smallestDisplacement = 0,
-
-  /// If set to true, the app will wait for an accurate location.
-  /// Only valid on Android.
-  bool waitForAccurateLocation = true,
-
-  /// The accptable accuracy of the location request.
-  /// Only valid on Android.
-  double? acceptableAccuracy,
+  /// Whether the underlying platform location manager may pause updates to
+  /// improve battery life. Only used on iOS and macOS.
+  bool? pausesLocationUpdatesAutomatically = true,
 })
 ```
 
-When you call `setLocationSettings`, the current `onLocationChanged` will be updated with the new settings without being closed.
+When you call `changeSettings`, an active `onLocationChanged` stream is updated with the new settings without being closed. The next `getLocation` call also uses them.
 
-The next `getLocation` call will also use the new settings.
+## Example
+
+```dart
+final location = Location();
+await location.changeSettings(
+    accuracy: LocationAccuracy.high,
+    interval: 1000,
+    distanceFilter: 0,
+);
+```

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -9,7 +9,7 @@ In order to install the plugin, just add the latest version from
 
 ```yaml
 dependencies:
-  location: ^8.0.1
+  location: ^9.0.0
 ```
 
 You can then follow the different guide depending on which platform you wish to

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -30,8 +30,9 @@ Start by [installing Location](/getting-started)!
 Then, to get the location of your user you can simply do:
 
 ```dart
-final location = await getLocation();
-print("Location: ${location.latitude}, ${location.longitude}");
+final location = Location();
+final locationData = await location.getLocation();
+print("Location: ${locationData.latitude}, ${locationData.longitude}");
 ```
 
 [flutter favorite]: https://docs.flutter.dev/packages-and-plugins/favorites

--- a/packages/location/lib/location.dart
+++ b/packages/location/lib/location.dart
@@ -22,10 +22,11 @@ class Location implements LocationPlatform {
   /// Changes settings of the location request.
   ///
   /// The [accuracy] argument is controlling the precision of the
-  /// [LocationData]. The [interval] and [distanceFilter] are controlling how
-  /// often a new location is sent through [onLocationChanged]. The
-  /// [pausesLocationUpdatesAutomatically] argument indicates whether the
-  /// underlying location manager object may pause location updates.
+  /// [LocationData]. The [interval] (in milliseconds) and [distanceFilter] (in
+  /// meters) control how often a new location is sent through
+  /// [onLocationChanged]. The [pausesLocationUpdatesAutomatically] argument
+  /// indicates whether the underlying location manager object may pause location
+  /// updates.
   ///
   /// [interval] and [distanceFilter] are not used on web.
   @override


### PR DESCRIPTION
## Problem

The documentation site (`docs/`) describes an API that **was never shipped** — it documents the abandoned v5 redesign. Every code sample on the site fails to compile against the published package. Examples of phantom API used in the docs:

| Docs say | Actually shipped |
|---|---|
| `getLocation({LocationSettings? settings})` | `getLocation()` (no args) |
| `setLocationSettings({...})` | `changeSettings({accuracy, interval, distanceFilter, pausesLocationUpdatesAutomatically})` |
| `onLocationChanged({bool inBackground})` | `onLocationChanged` (Stream getter) + `enableBackgroundMode` |
| `getPermissionStatus()`, `requestPermissions` | `hasPermission()`, `requestPermission()` |
| `PermissionStatus.authorizedAlways/authorizedWhenInUse/notDetermined` | `granted / grantedLimited / denied / deniedForever` |
| `isGPSEnabled()`, `isNetworkEnabled()` | `serviceEnabled()`, `requestService()` |
| `updateBackgroundNotification`, `changeBackgroundOptions` | `changeNotificationOptions` |
| top-level `getLocation()` | called on a `Location` instance |

## Fix

Rewrote the affected pages against the **real** API, using the package source (`location.dart`, the `PermissionStatus`/`LocationAccuracy` enums) and the example app as the source of truth. 8 files: `index`, `getting-started` (→ `location: ^9.0.0`), and the `get-location` / `listen-location` / `settings` / `permissions` / `services` / `notification` feature pages.

Verified with a repo-wide grep that no phantom-API symbol remains and every snippet now calls the API on a `Location` instance.

Docs-site only — no package code and no CHANGELOG change.

## Also closes

Fixes #985 — the `changeSettings` doc comment and the Settings page now state `interval` is in milliseconds and `distanceFilter` in meters.

Fixes #951 — `pausesLocationUpdatesAutomatically` was added as a `changeSettings` parameter in 9.0.0 and is now documented on the Settings page.