### PR TITLE
docs(location_web): fix broken location link in README

### DIFF
--- a/packages/location_web/README.md
+++ b/packages/location_web/README.md
@@ -20,4 +20,4 @@ dependencies:
 
 Once you have `location` in `pubspec.yaml` you should be able to use `package:location` as normal.
 
-[1]: ../location
+[1]: https://pub.dev/packages/location


### PR DESCRIPTION
The `location` reference link in `packages/location_web/README.md` used a relative path (`../location`) that resolves fine on GitHub but 404s on pub.dev. Changed it to the absolute URL `https://pub.dev/packages/location`.

Fixes #769