### PR TITLE
feat(darwin): populate isMock on iOS/macOS

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### 🍎 iOS & macOS
 
+- Populated `LocationData.isMock` on Apple platforms. On iOS 15.0+/macOS 12.0+
+  it reflects `CLLocation.sourceInformation.isSimulatedBySoftware`; on older
+  systems it stays `false`, as Core Location exposes no equivalent flag (#796).
 - Moved `CLLocationManager.locationServicesEnabled()` off the main thread. Apple
   warns that this call can block the caller while location services start up;
   invoking it on the main thread triggered the "UI unresponsiveness" runtime

--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -342,6 +342,18 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
         }
 
         let timeInMilliseconds = location.timestamp.timeIntervalSince1970 * 1000
+
+        // Detect simulated/mocked locations. `sourceInformation` is only
+        // available on iOS 15.0+/macOS 12.0+; on older systems Core Location
+        // exposes no such flag, so default to not-mocked. The Dart side reads
+        // this under the same `isMock` key Android uses.
+        var isMock = false
+        if #available(iOS 15.0, macOS 12.0, *) {
+            if let source: CLLocationSourceInformation = location.sourceInformation {
+                isMock = source.isSimulatedBySoftware
+            }
+        }
+
         let coordinates: [String: Any] = [
             "latitude": location.coordinate.latitude,
             "longitude": location.coordinate.longitude,
@@ -352,6 +364,7 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
             "speed_accuracy": location.speedAccuracy,
             "heading": location.course,
             "time": timeInMilliseconds,
+            "isMock": isMock ? 1 : 0,
         ]
 
         if locationWanted {

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -83,7 +83,8 @@ class LocationData {
 
   /// Is the location currently mocked
   ///
-  /// Always false on iOS
+  /// On iOS 15.0+/macOS 12.0+ this reflects `isSimulatedBySoftware`; on older
+  /// Apple systems it is always false, as Core Location exposes no such flag.
   final bool? isMock;
 
   /// Get the estimated bearing accuracy of this location, in degrees.


### PR DESCRIPTION
## Summary

`LocationData.isMock` was only populated on Android; iOS/macOS always reported `false`. This wires it up on Apple platforms.

In `LocationPlugin.locationManager(_:didUpdateLocations:)`, the location's simulated state is read from `CLLocation.sourceInformation?.isSimulatedBySoftware` (available on iOS 15.0+/macOS 12.0+, guarded with `if #available`) and sent under the existing `isMock` key that the Dart side already parses into `LocationData.isMock`. On older Apple systems Core Location exposes no such flag, so it defaults to `false`.

Fixes #796

## Verification

Built the iOS example against the simulator:

```
cd packages/location/example && flutter build ios --simulator --no-codesign
...
Xcode build done.                                           19.3s
✓ Built build/ios/iphonesimulator/Runner.app
```