### PR TITLE
feat(location): add toJson, fromJson and copyWith to LocationData

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -3,6 +3,13 @@
 <!-- Not yet published to pub.dev. Accumulate fixes here; assign a version
      number when we cut the next release. -->
 
+### 🎯 Dart API
+
+- Added `LocationData.toJson()`, `LocationData.fromJson()` and
+  `LocationData.copyWith()`, so `LocationData` can be serialized, deserialized
+  and copied without manual field wiring. `fromJson` round-trips with `toJson`
+  across every field (#760).
+
 ### 🍎 iOS & macOS
 
 - Moved `CLLocationManager.locationServicesEnabled()` off the main thread. Apple

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -137,22 +137,22 @@ class LocationData {
   /// Converts this [LocationData] into a JSON map. This round-trips with
   /// [LocationData.fromJson].
   Map<String, dynamic> toJson() => <String, dynamic>{
-    'latitude': latitude,
-    'longitude': longitude,
-    'accuracy': accuracy,
-    'verticalAccuracy': verticalAccuracy,
-    'altitude': altitude,
-    'speed': speed,
-    'speedAccuracy': speedAccuracy,
-    'heading': heading,
-    'time': time,
-    'isMock': isMock,
-    'headingAccuracy': headingAccuracy,
-    'elapsedRealtimeNanos': elapsedRealtimeNanos,
-    'elapsedRealtimeUncertaintyNanos': elapsedRealtimeUncertaintyNanos,
-    'satelliteNumber': satelliteNumber,
-    'provider': provider,
-  };
+        'latitude': latitude,
+        'longitude': longitude,
+        'accuracy': accuracy,
+        'verticalAccuracy': verticalAccuracy,
+        'altitude': altitude,
+        'speed': speed,
+        'speedAccuracy': speedAccuracy,
+        'heading': heading,
+        'time': time,
+        'isMock': isMock,
+        'headingAccuracy': headingAccuracy,
+        'elapsedRealtimeNanos': elapsedRealtimeNanos,
+        'elapsedRealtimeUncertaintyNanos': elapsedRealtimeUncertaintyNanos,
+        'satelliteNumber': satelliteNumber,
+        'provider': provider,
+      };
 
   /// Returns a copy of this [LocationData] with the given fields replaced by
   /// the new values. Any argument left `null` keeps the current value.
@@ -220,22 +220,22 @@ class LocationData {
 
   @override
   int get hashCode => Object.hash(
-    latitude,
-    longitude,
-    accuracy,
-    verticalAccuracy,
-    altitude,
-    speed,
-    speedAccuracy,
-    heading,
-    time,
-    isMock,
-    headingAccuracy,
-    elapsedRealtimeNanos,
-    elapsedRealtimeUncertaintyNanos,
-    satelliteNumber,
-    provider,
-  );
+        latitude,
+        longitude,
+        accuracy,
+        verticalAccuracy,
+        altitude,
+        speed,
+        speedAccuracy,
+        heading,
+        time,
+        isMock,
+        headingAccuracy,
+        elapsedRealtimeNanos,
+        elapsedRealtimeUncertaintyNanos,
+        satelliteNumber,
+        provider,
+      );
 }
 
 /// Precision of the Location. A lower precision will provide a greater battery

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -41,6 +41,28 @@ class LocationData {
     );
   }
 
+  /// Creates a new [LocationData] instance from a JSON map, as produced by
+  /// [toJson]. This round-trips with [toJson].
+  factory LocationData.fromJson(Map<String, dynamic> json) {
+    return LocationData._(
+      (json['latitude'] as num?)?.toDouble(),
+      (json['longitude'] as num?)?.toDouble(),
+      (json['accuracy'] as num?)?.toDouble(),
+      (json['altitude'] as num?)?.toDouble(),
+      (json['speed'] as num?)?.toDouble(),
+      (json['speedAccuracy'] as num?)?.toDouble(),
+      (json['heading'] as num?)?.toDouble(),
+      (json['time'] as num?)?.toDouble(),
+      json['isMock'] as bool?,
+      (json['verticalAccuracy'] as num?)?.toDouble(),
+      (json['headingAccuracy'] as num?)?.toDouble(),
+      (json['elapsedRealtimeNanos'] as num?)?.toDouble(),
+      (json['elapsedRealtimeUncertaintyNanos'] as num?)?.toDouble(),
+      json['satelliteNumber'] as int?,
+      json['provider'] as String?,
+    );
+  }
+
   /// Latitude in degrees
   final double? latitude;
 
@@ -111,6 +133,64 @@ class LocationData {
   /// https://developer.android.com/reference/android/location/Location#getProvider()
   final String? provider;
 
+  /// Converts this [LocationData] into a JSON map. This round-trips with
+  /// [LocationData.fromJson].
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'latitude': latitude,
+        'longitude': longitude,
+        'accuracy': accuracy,
+        'verticalAccuracy': verticalAccuracy,
+        'altitude': altitude,
+        'speed': speed,
+        'speedAccuracy': speedAccuracy,
+        'heading': heading,
+        'time': time,
+        'isMock': isMock,
+        'headingAccuracy': headingAccuracy,
+        'elapsedRealtimeNanos': elapsedRealtimeNanos,
+        'elapsedRealtimeUncertaintyNanos': elapsedRealtimeUncertaintyNanos,
+        'satelliteNumber': satelliteNumber,
+        'provider': provider,
+      };
+
+  /// Returns a copy of this [LocationData] with the given fields replaced by
+  /// the new values. Any argument left `null` keeps the current value.
+  LocationData copyWith({
+    double? latitude,
+    double? longitude,
+    double? accuracy,
+    double? verticalAccuracy,
+    double? altitude,
+    double? speed,
+    double? speedAccuracy,
+    double? heading,
+    double? time,
+    bool? isMock,
+    double? headingAccuracy,
+    double? elapsedRealtimeNanos,
+    double? elapsedRealtimeUncertaintyNanos,
+    int? satelliteNumber,
+    String? provider,
+  }) {
+    return LocationData._(
+      latitude ?? this.latitude,
+      longitude ?? this.longitude,
+      accuracy ?? this.accuracy,
+      altitude ?? this.altitude,
+      speed ?? this.speed,
+      speedAccuracy ?? this.speedAccuracy,
+      heading ?? this.heading,
+      time ?? this.time,
+      isMock ?? this.isMock,
+      verticalAccuracy ?? this.verticalAccuracy,
+      headingAccuracy ?? this.headingAccuracy,
+      elapsedRealtimeNanos ?? this.elapsedRealtimeNanos,
+      elapsedRealtimeUncertaintyNanos ?? this.elapsedRealtimeUncertaintyNanos,
+      satelliteNumber ?? this.satelliteNumber,
+      provider ?? this.provider,
+    );
+  }
+
   @override
   String toString() =>
       'LocationData<lat: $latitude, long: $longitude${(isMock ?? false) ? ', mocked' : ''}>';
@@ -123,24 +203,38 @@ class LocationData {
           latitude == other.latitude &&
           longitude == other.longitude &&
           accuracy == other.accuracy &&
+          verticalAccuracy == other.verticalAccuracy &&
           altitude == other.altitude &&
           speed == other.speed &&
           speedAccuracy == other.speedAccuracy &&
           heading == other.heading &&
           time == other.time &&
-          isMock == other.isMock;
+          isMock == other.isMock &&
+          headingAccuracy == other.headingAccuracy &&
+          elapsedRealtimeNanos == other.elapsedRealtimeNanos &&
+          elapsedRealtimeUncertaintyNanos ==
+              other.elapsedRealtimeUncertaintyNanos &&
+          satelliteNumber == other.satelliteNumber &&
+          provider == other.provider;
 
   @override
-  int get hashCode =>
-      latitude.hashCode ^
-      longitude.hashCode ^
-      accuracy.hashCode ^
-      altitude.hashCode ^
-      speed.hashCode ^
-      speedAccuracy.hashCode ^
-      heading.hashCode ^
-      time.hashCode ^
-      isMock.hashCode;
+  int get hashCode => Object.hash(
+        latitude,
+        longitude,
+        accuracy,
+        verticalAccuracy,
+        altitude,
+        speed,
+        speedAccuracy,
+        heading,
+        time,
+        isMock,
+        headingAccuracy,
+        elapsedRealtimeNanos,
+        elapsedRealtimeUncertaintyNanos,
+        satelliteNumber,
+        provider,
+      );
 }
 
 /// Precision of the Location. A lower precision will provide a greater battery

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -136,22 +136,22 @@ class LocationData {
   /// Converts this [LocationData] into a JSON map. This round-trips with
   /// [LocationData.fromJson].
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'latitude': latitude,
-        'longitude': longitude,
-        'accuracy': accuracy,
-        'verticalAccuracy': verticalAccuracy,
-        'altitude': altitude,
-        'speed': speed,
-        'speedAccuracy': speedAccuracy,
-        'heading': heading,
-        'time': time,
-        'isMock': isMock,
-        'headingAccuracy': headingAccuracy,
-        'elapsedRealtimeNanos': elapsedRealtimeNanos,
-        'elapsedRealtimeUncertaintyNanos': elapsedRealtimeUncertaintyNanos,
-        'satelliteNumber': satelliteNumber,
-        'provider': provider,
-      };
+    'latitude': latitude,
+    'longitude': longitude,
+    'accuracy': accuracy,
+    'verticalAccuracy': verticalAccuracy,
+    'altitude': altitude,
+    'speed': speed,
+    'speedAccuracy': speedAccuracy,
+    'heading': heading,
+    'time': time,
+    'isMock': isMock,
+    'headingAccuracy': headingAccuracy,
+    'elapsedRealtimeNanos': elapsedRealtimeNanos,
+    'elapsedRealtimeUncertaintyNanos': elapsedRealtimeUncertaintyNanos,
+    'satelliteNumber': satelliteNumber,
+    'provider': provider,
+  };
 
   /// Returns a copy of this [LocationData] with the given fields replaced by
   /// the new values. Any argument left `null` keeps the current value.
@@ -219,22 +219,22 @@ class LocationData {
 
   @override
   int get hashCode => Object.hash(
-        latitude,
-        longitude,
-        accuracy,
-        verticalAccuracy,
-        altitude,
-        speed,
-        speedAccuracy,
-        heading,
-        time,
-        isMock,
-        headingAccuracy,
-        elapsedRealtimeNanos,
-        elapsedRealtimeUncertaintyNanos,
-        satelliteNumber,
-        provider,
-      );
+    latitude,
+    longitude,
+    accuracy,
+    verticalAccuracy,
+    altitude,
+    speed,
+    speedAccuracy,
+    heading,
+    time,
+    isMock,
+    headingAccuracy,
+    elapsedRealtimeNanos,
+    elapsedRealtimeUncertaintyNanos,
+    satelliteNumber,
+    provider,
+  );
 }
 
 /// Precision of the Location. A lower precision will provide a greater battery
@@ -279,7 +279,7 @@ enum PermissionStatus {
 
   /// The permission to use location services has been denied forever by the
   /// user. No dialog will be displayed on permission request.
-  deniedForever
+  deniedForever,
 }
 
 /// The response object of `Location.changeNotificationOptions`.

--- a/packages/location_platform_interface/test/types_test.dart
+++ b/packages/location_platform_interface/test/types_test.dart
@@ -65,6 +65,89 @@ void main() {
       expect(otherLocationData == locationData, false);
       expect(otherLocationData.hashCode == locationData.hashCode, false);
     });
+
+    test('toJson exposes every field of LocationData', () {
+      final locationData = LocationData.fromJson(<String, dynamic>{
+        'latitude': 42.0,
+        'longitude': 2.0,
+        'accuracy': 3.0,
+        'verticalAccuracy': 4.0,
+        'altitude': 5.0,
+        'speed': 6.0,
+        'speedAccuracy': 7.0,
+        'heading': 8.0,
+        'time': 9.0,
+        'isMock': true,
+        'headingAccuracy': 10.0,
+        'elapsedRealtimeNanos': 11.0,
+        'elapsedRealtimeUncertaintyNanos': 12.0,
+        'satelliteNumber': 13,
+        'provider': 'gps',
+      });
+
+      expect(locationData.toJson(), <String, dynamic>{
+        'latitude': 42.0,
+        'longitude': 2.0,
+        'accuracy': 3.0,
+        'verticalAccuracy': 4.0,
+        'altitude': 5.0,
+        'speed': 6.0,
+        'speedAccuracy': 7.0,
+        'heading': 8.0,
+        'time': 9.0,
+        'isMock': true,
+        'headingAccuracy': 10.0,
+        'elapsedRealtimeNanos': 11.0,
+        'elapsedRealtimeUncertaintyNanos': 12.0,
+        'satelliteNumber': 13,
+        'provider': 'gps',
+      });
+    });
+
+    test('fromJson(toJson) round-trips with all fields set', () {
+      final locationData = LocationData.fromJson(<String, dynamic>{
+        'latitude': 42.0,
+        'longitude': 2.0,
+        'accuracy': 3.0,
+        'verticalAccuracy': 4.0,
+        'altitude': 5.0,
+        'speed': 6.0,
+        'speedAccuracy': 7.0,
+        'heading': 8.0,
+        'time': 9.0,
+        'isMock': true,
+        'headingAccuracy': 10.0,
+        'elapsedRealtimeNanos': 11.0,
+        'elapsedRealtimeUncertaintyNanos': 12.0,
+        'satelliteNumber': 13,
+        'provider': 'gps',
+      });
+
+      final roundTripped = LocationData.fromJson(locationData.toJson());
+
+      expect(roundTripped, locationData);
+      expect(roundTripped.hashCode, locationData.hashCode);
+    });
+
+    test('fromJson(toJson) round-trips with null fields', () {
+      final locationData = LocationData.fromJson(<String, dynamic>{});
+
+      expect(LocationData.fromJson(locationData.toJson()), locationData);
+    });
+
+    test('copyWith replaces only the provided fields', () {
+      final locationData = LocationData.fromJson(<String, dynamic>{
+        'latitude': 42.0,
+        'longitude': 2.0,
+        'provider': 'gps',
+      });
+
+      final updated = locationData.copyWith(longitude: 3.5, provider: 'network');
+
+      expect(updated.latitude, 42.0);
+      expect(updated.longitude, 3.5);
+      expect(updated.provider, 'network');
+    });
   });
 
   group('$AndroidNotificationData', () {

--- a/packages/location_platform_interface/test/types_test.dart
+++ b/packages/location_platform_interface/test/types_test.dart
@@ -142,7 +142,10 @@ void main() {
         'provider': 'gps',
       });
 
-      final updated = locationData.copyWith(longitude: 3.5, provider: 'network');
+      final updated = locationData.copyWith(
+        longitude: 3.5,
+        provider: 'network',
+      );
 
       expect(updated.latitude, 42.0);
       expect(updated.longitude, 3.5);
@@ -152,52 +155,40 @@ void main() {
 
   group('$AndroidNotificationData', () {
     test('AndroidNotificationData should be correctly converted to string', () {
-      final androidNotificationData =
-          AndroidNotificationData.fromMap(<String, dynamic>{
-        'channelId': 'test-id',
-        'notificationId': 2,
-      });
+      final androidNotificationData = AndroidNotificationData.fromMap(
+        <String, dynamic>{'channelId': 'test-id', 'notificationId': 2},
+      );
       expect(
         androidNotificationData.toString(),
         'AndroidNotificationData<channelId: test-id, notificationId: 2>',
       );
     });
 
-    test('AndroidNotificationData should be equal if all parameters are equals',
-        () {
-      final androidNotificationData = AndroidNotificationData.fromMap(
-        <String, dynamic>{
-          'channelId': 'test-id',
-          'notificationId': 2,
-        },
-      );
-      final otherAndroidNotificationData = AndroidNotificationData.fromMap(
-        <String, dynamic>{
-          'channelId': 'test-id',
-          'notificationId': 2,
-        },
-      );
+    test(
+      'AndroidNotificationData should be equal if all parameters are equals',
+      () {
+        final androidNotificationData = AndroidNotificationData.fromMap(
+          <String, dynamic>{'channelId': 'test-id', 'notificationId': 2},
+        );
+        final otherAndroidNotificationData = AndroidNotificationData.fromMap(
+          <String, dynamic>{'channelId': 'test-id', 'notificationId': 2},
+        );
 
-      expect(otherAndroidNotificationData == androidNotificationData, true);
-      expect(
-        otherAndroidNotificationData.hashCode ==
-            androidNotificationData.hashCode,
-        true,
-      );
-    });
+        expect(otherAndroidNotificationData == androidNotificationData, true);
+        expect(
+          otherAndroidNotificationData.hashCode ==
+              androidNotificationData.hashCode,
+          true,
+        );
+      },
+    );
 
     test('LocationData should be different if one parameters is different', () {
       final androidNotificationData = AndroidNotificationData.fromMap(
-        <String, dynamic>{
-          'channelId': 'test-id',
-          'notificationId': 2,
-        },
+        <String, dynamic>{'channelId': 'test-id', 'notificationId': 2},
       );
       final otherAndroidNotificationData = AndroidNotificationData.fromMap(
-        <String, dynamic>{
-          'channelId': 'test-id',
-          'notificationId': 3,
-        },
+        <String, dynamic>{'channelId': 'test-id', 'notificationId': 3},
       );
 
       expect(otherAndroidNotificationData == androidNotificationData, false);


### PR DESCRIPTION
## Summary

`LocationData` had no serialization helpers. This adds them to
`packages/location_platform_interface/lib/src/types.dart`:

- `Map<String, dynamic> toJson()` covering **every** field (latitude, longitude,
  accuracy, verticalAccuracy, altitude, speed, speedAccuracy, heading, time,
  isMock, headingAccuracy, elapsedRealtimeNanos, elapsedRealtimeUncertaintyNanos,
  satelliteNumber, provider).
- `factory LocationData.fromJson(Map<String, dynamic> json)` that round-trips
  with `toJson`.
- `copyWith(...)` returning a copy with selected fields replaced.
- Extended `operator ==` and `hashCode` to cover all fields (previously only a
  subset), so round-trip equality is meaningful.

Existing `fromMap`/`toString` behaviour is unchanged.

Fixes #760

## Verification

- `cd packages/location_platform_interface && flutter test` — **All tests passed!**
  (31 tests, including new round-trip, field-coverage and copyWith tests in
  `test/types_test.dart`).
- `cd packages/location_platform_interface && flutter analyze` — **No issues found!**
