### PR TITLE
fix(android): report grantedLimited for approximate-only location on API 31+

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -3,6 +3,13 @@
 <!-- Not yet published to pub.dev. Accumulate fixes here; assign a version
      number when we cut the next release. -->
 
+### 🤖 Android
+
+- Report `PermissionStatus.grantedLimited` when the user grants only approximate
+  (coarse) location without precise (fine) location on Android 12+ (API 31+),
+  mirroring iOS reduced accuracy. Previously this coarse-only case was reported as
+  `granted` (#736).
+
 ### 🍎 iOS & macOS
 
 - Moved `CLLocationManager.locationServicesEnabled()` off the main thread. Apple

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -119,7 +119,15 @@ class FlutterLocation(
                 if (getLocationResult != null || events != null) {
                     startRequestingLocation()
                 }
-                result?.success(1)
+                // Approximate-only (coarse without fine) on Android 12+ maps to
+                // grantedLimited (3); precise access maps to granted (1) (#736).
+                val code =
+                    if (!fineGranted && coarseGranted && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        3
+                    } else {
+                        1
+                    }
+                result?.success(code)
                 result = null
             } else {
                 if (!shouldShowRequestPermissionRationale()) {
@@ -309,6 +317,30 @@ class FlutterLocation(
             PackageManager.PERMISSION_GRANTED
     }
 
+    private fun hasCoarseLocationPermission(): Boolean {
+        val activity = this.activity ?: return false
+        return ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    /**
+     * Computes the permission status code sent to Dart:
+     * 1 = granted (precise), 3 = grantedLimited (approximate-only), 0 = denied.
+     *
+     * On Android 12+ (API 31+) a user can grant only ACCESS_COARSE_LOCATION
+     * (approximate) without ACCESS_FINE_LOCATION. That case maps to
+     * grantedLimited, mirroring iOS reduced accuracy (#736).
+     */
+    fun permissionStatusCode(): Int {
+        if (hasFineLocationPermission()) {
+            return 1
+        }
+        if (hasCoarseLocationPermission()) {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 3 else 1
+        }
+        return 0
+    }
+
     fun requestPermissions() {
         val activity = this.activity
         if (activity == null) {
@@ -316,7 +348,7 @@ class FlutterLocation(
             throw ActivityNotFoundException()
         }
         if (checkPermissions()) {
-            result?.success(1)
+            result?.success(permissionStatusCode())
             return
         }
         ActivityCompat.requestPermissions(

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
@@ -125,11 +125,9 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
             return
         }
 
-        if (location.checkPermissions()) {
-            result.success(1)
-        } else {
-            result.success(0)
-        }
+        // permissionStatusCode() returns 1 (granted), 3 (grantedLimited,
+        // approximate-only on API 31+) or 0 (denied) (#736).
+        result.success(location.permissionStatusCode())
     }
 
     private fun onServiceEnabled(


### PR DESCRIPTION
Fixes #736

## Problem

On Android 12+ (API 31+), a user can grant only **approximate** (`ACCESS_COARSE_LOCATION`) location without **precise** (`ACCESS_FINE_LOCATION`). In that case the plugin reported `PermissionStatus.granted`, hiding the reduced-accuracy state from apps. iOS already surfaces this via `PermissionStatus.grantedLimited`.

## Change

Added `permissionStatusCode()` to `FlutterLocation`, which returns the integer code the Dart side maps to a `PermissionStatus`:

- `1` -> `granted` (fine granted)
- `3` -> `grantedLimited` (coarse granted, fine not granted, **API >= 31**)
- `0` -> `denied`

Wired it through the permission paths:

- `hasPermission` (`MethodCallHandlerImpl.onHasPermission`)
- `requestPermission` early-return when already granted (`FlutterLocation.requestPermissions`)
- the permission-result callback (`FlutterLocation.onRequestPermissionsResult`), using the actual `fineGranted`/`coarseGranted` results

On API < 31 the coarse-only case keeps returning `granted`, preserving existing behavior. The Dart mapping (`method_channel_location.dart`) already decodes `3` to `PermissionStatus.grantedLimited`, so no Dart changes were needed.

## Verification

- `flutter build apk --debug` in `packages/location/example` succeeds (`Built build/app/outputs/flutter-apk/app-debug.apk`), confirming the Kotlin compiles.
- No Dart was touched; `flutter analyze` on `location_platform_interface` reports no issues.