### PR TITLE
docs(location): clarify enableBackgroundMode can request background permission independently

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -21,6 +21,13 @@
   skips fixes by age instead, so the first fresh update always resolves the call
   (#798, #955, #1005, #660, #824, #657, #1013).
 
+### 📝 Docs
+
+- Clarified that `enableBackgroundMode(enable: true)` is a standalone call that
+  can be made before listening to `onLocationChanged`, and that on Android it
+  requests the `ACCESS_BACKGROUND_LOCATION` permission when needed — so
+  background permission can be requested independently (#756).
+
 ## 9.0.0
 
 A major maintenance release that modernises every platform and adds desktop

--- a/packages/location/README.md
+++ b/packages/location/README.md
@@ -158,6 +158,12 @@ To receive location when application is in background you have to enable it:
 location.enableBackgroundMode(enable: true)
 ```
 
+`enableBackgroundMode(enable: true)` is a standalone call: you can invoke it
+**before** you start listening to `onLocationChanged`. On Android it also
+requests the `ACCESS_BACKGROUND_LOCATION` permission when it has not been granted
+yet, so you can use it to prompt for background permission independently, without
+having to activate a location stream first.
+
 Be sure to check the example project to get other code samples.
 
 On Android, a foreground notification is displayed with information that location service is running in the background.

--- a/packages/location/lib/location.dart
+++ b/packages/location/lib/location.dart
@@ -51,6 +51,11 @@ class Location implements LocationPlatform {
   }
 
   /// Enables or disables service in the background mode.
+  ///
+  /// This can be called independently, before you start listening to
+  /// [onLocationChanged]. On Android, enabling background mode also requests the
+  /// `ACCESS_BACKGROUND_LOCATION` permission if it has not been granted yet, so
+  /// it can be used to prompt for background location permission on its own.
   @override
   Future<bool> enableBackgroundMode({bool? enable = true}) {
     return LocationPlatform.instance.enableBackgroundMode(enable: enable);

--- a/packages/location_platform_interface/lib/location_platform_interface.dart
+++ b/packages/location_platform_interface/lib/location_platform_interface.dart
@@ -56,6 +56,10 @@ class LocationPlatform extends PlatformInterface {
   }
 
   /// Enables or disables service in the background mode.
+  ///
+  /// This can be called independently, before listening to [onLocationChanged].
+  /// On Android, enabling background mode also requests the
+  /// `ACCESS_BACKGROUND_LOCATION` permission if it has not been granted yet.
   Future<bool> enableBackgroundMode({bool? enable}) {
     throw UnimplementedError();
   }


### PR DESCRIPTION
## Summary

Issue #756 asked to make `setBackgroundActivated` public so that background-location permission can be requested independently, before starting to listen for updates.

Investigation shows this capability **already exists** in the current API. The old internal `setBackgroundActivated` method no longer exists; it was superseded by the public `enableBackgroundMode({bool? enable})`, exposed on `Location`, `LocationPlatform` and `MethodChannelLocation`.

`enableBackgroundMode(enable: true)`:

- is a standalone call — it does **not** require an active `onLocationChanged` subscription, so it can be invoked beforehand;
- on Android, when `ACCESS_BACKGROUND_LOCATION` is not yet granted, triggers `requestBackgroundPermissions()` (see `FlutterLocationService.requestBackgroundPermissions` / `MethodCallHandlerImpl.enableBackgroundMode`), i.e. it prompts for the background permission independently;
- on iOS, toggles `allowsBackgroundLocationUpdates`.

So no new API is warranted — the honest fix is a documentation clarification so users discover this. This PR:

- Adds a note in the README background section explaining the call is standalone and requests `ACCESS_BACKGROUND_LOCATION` on Android.
- Expands the dartdoc on the public `Location.enableBackgroundMode` and on `LocationPlatform.enableBackgroundMode` so the behavior is visible in-IDE.
- Adds a `📝 Docs` bullet under the existing `## Unreleased` CHANGELOG section (no version bump).

No runtime behavior changes.

Fixes #756

## Verification

- `flutter analyze` in `packages/location` — No issues found.
- `flutter analyze` in `packages/location_platform_interface` — No issues found.
- Docs/dartdoc only, no runtime surface changed, so no build step required.