### PR TITLE
feat(location): expose whether background (Always) location permission is granted

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -3,6 +3,16 @@
 <!-- Not yet published to pub.dev. Accumulate fixes here; assign a version
      number when we cut the next release. -->
 
+### ✨ Features
+
+- Added `Location.isBackgroundPermissionGranted()`, which reports whether the
+  app has been granted background ("Allow all the time" / Always) location
+  access. Call it before `enableBackgroundMode` to show an in-app rationale
+  before sending the user to the system settings. On iOS/macOS it is `true`
+  only for the "Always" authorization; on Android it reflects the
+  `ACCESS_BACKGROUND_LOCATION` permission on API 29+ and mirrors
+  `hasPermission()` on older versions; on web it is always `false` (#538).
+
 ### 🍎 iOS & macOS
 
 - Moved `CLLocationManager.locationServicesEnabled()` off the main thread. Apple

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -303,6 +303,29 @@ class FlutterLocation(
             coarseState == PackageManager.PERMISSION_GRANTED
     }
 
+    /**
+     * Returns whether background ("Allow all the time") location access has been
+     * granted.
+     *
+     * On API 29+ (Android 10) background access is a dedicated runtime
+     * permission, [Manifest.permission.ACCESS_BACKGROUND_LOCATION], distinct
+     * from the foreground fine/coarse permissions. On older versions there is no
+     * separate background permission — a foreground grant already allows
+     * background access — so this mirrors [checkPermissions].
+     */
+    fun checkBackgroundPermissions(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return checkPermissions()
+        }
+        val activity = this.activity
+        if (activity == null) {
+            result?.error("MISSING_ACTIVITY", "You should not checkPermissions activation outside of an activity.", null)
+            throw ActivityNotFoundException()
+        }
+        return ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
     private fun hasFineLocationPermission(): Boolean {
         val activity = this.activity ?: return false
         return ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) ==

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
@@ -37,6 +37,7 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
             "changeSettings" -> onChangeSettings(call, result, location)
             "getLocation" -> onGetLocation(result, location)
             "hasPermission" -> onHasPermission(result, location)
+            "isBackgroundPermissionGranted" -> onIsBackgroundPermissionGranted(result, location)
             "requestPermission" -> onRequestPermission(result, location)
             "serviceEnabled" -> onServiceEnabled(result, location)
             "requestService" -> location.requestService(result)
@@ -130,6 +131,13 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
         } else {
             result.success(0)
         }
+    }
+
+    private fun onIsBackgroundPermissionGranted(
+        result: Result,
+        location: FlutterLocation,
+    ) {
+        result.success(if (location.checkBackgroundPermissions()) 1 else 0)
     }
 
     private fun onServiceEnabled(

--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -67,6 +67,8 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
             onGetLocation(result: result)
         case "hasPermission":
             onHasPermission(result: result)
+        case "isBackgroundPermissionGranted":
+            onIsBackgroundPermissionGranted(result: result)
         case "requestPermission":
             onRequestPermission(result: result)
         case "serviceEnabled":
@@ -196,6 +198,14 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
         } else {
             result(0)
         }
+    }
+
+    /// Whether background ("Always") location authorization has been granted.
+    ///
+    /// On both iOS and macOS this maps to `.authorizedAlways`; the more limited
+    /// `.authorizedWhenInUse` does not grant background access.
+    private func onIsBackgroundPermissionGranted(result: FlutterResult) {
+        result(currentAuthorizationStatus == .authorizedAlways ? 1 : 0)
     }
 
     private func onRequestPermission(result: @escaping FlutterResult) {

--- a/packages/location/lib/location.dart
+++ b/packages/location/lib/location.dart
@@ -82,6 +82,22 @@ class Location implements LocationPlatform {
     return LocationPlatform.instance.requestPermission();
   }
 
+  /// Checks whether the app has been granted background ("Allow all the time")
+  /// location access, in addition to foreground access.
+  ///
+  /// Use this before calling [enableBackgroundMode] to decide whether to show
+  /// an in-app rationale before sending the user to the system settings.
+  ///
+  /// - iOS/macOS: `true` only when the authorization status is "Always".
+  /// - Android: reflects the `ACCESS_BACKGROUND_LOCATION` runtime permission on
+  ///   API 29+ (Android 10). On older versions background access is implied by
+  ///   the foreground grant, so this mirrors [hasPermission].
+  /// - Web: always `false`.
+  @override
+  Future<bool> isBackgroundPermissionGranted() {
+    return LocationPlatform.instance.isBackgroundPermissionGranted();
+  }
+
   /// Checks if the location service is enabled.
   @override
   Future<bool> serviceEnabled() {

--- a/packages/location_platform_interface/lib/location_platform_interface.dart
+++ b/packages/location_platform_interface/lib/location_platform_interface.dart
@@ -86,6 +86,22 @@ class LocationPlatform extends PlatformInterface {
     throw UnimplementedError();
   }
 
+  /// Checks whether the app has been granted background ("Allow all the time")
+  /// location access, in addition to foreground access.
+  ///
+  /// This is useful before calling [enableBackgroundMode], to decide whether to
+  /// show an in-app rationale before sending the user to the system settings.
+  ///
+  /// - iOS/macOS: `true` only when the authorization status is "Always".
+  /// - Android: reflects the `ACCESS_BACKGROUND_LOCATION` runtime permission on
+  ///   API 29+ (Android 10). On older versions there is no separate background
+  ///   permission, so background access is implied by the foreground grant and
+  ///   this mirrors [hasPermission].
+  /// - Web: always `false`.
+  Future<bool> isBackgroundPermissionGranted() {
+    throw UnimplementedError();
+  }
+
   /// Checks if the location service is enabled.
   Future<bool> serviceEnabled() {
     throw UnimplementedError();

--- a/packages/location_platform_interface/lib/src/method_channel_location.dart
+++ b/packages/location_platform_interface/lib/src/method_channel_location.dart
@@ -107,6 +107,13 @@ class MethodChannelLocation extends LocationPlatform {
     return _parsePermissionStatus(result as int?);
   }
 
+  @override
+  Future<bool> isBackgroundPermissionGranted() async {
+    final result =
+        await _methodChannel!.invokeMethod('isBackgroundPermissionGranted');
+    return result == 1;
+  }
+
   PermissionStatus _parsePermissionStatus(int? result) {
     switch (result) {
       case 0:

--- a/packages/location_platform_interface/test/location_platform_interface_test.dart
+++ b/packages/location_platform_interface/test/location_platform_interface_test.dart
@@ -90,6 +90,15 @@ void main() {
     });
 
     test(
+        'Default implementation of isBackgroundPermissionGranted should throw unimplemented error',
+        () {
+      expect(
+        () => locationPlatform.isBackgroundPermissionGranted(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
         'Default implementation of serviceEnabled should throw unimplemented error',
         () {
       expect(

--- a/packages/location_platform_interface/test/method_channel_location_test.dart
+++ b/packages/location_platform_interface/test/method_channel_location_test.dart
@@ -131,6 +131,20 @@ void main() {
       expect(receivedPermission, PermissionStatus.grantedLimited);
     });
 
+    test('isBackgroundPermissionGranted converts results correctly', () async {
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        methodChannel!,
+        (methodCall) async => 1,
+      );
+      expect(await location.isBackgroundPermissionGranted(), true);
+
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        methodChannel!,
+        (methodCall) async => 0,
+      );
+      expect(await location.isBackgroundPermissionGranted(), false);
+    });
+
     test('Should throw if other message is sent', () async {
       binding.defaultBinaryMessenger.setMockMethodCallHandler(
         methodChannel!,

--- a/packages/location_web/lib/location_web.dart
+++ b/packages/location_web/lib/location_web.dart
@@ -84,6 +84,12 @@ class LocationWebPlugin extends LocationPlatform {
   }
 
   @override
+  Future<bool> isBackgroundPermissionGranted() async {
+    // The web platform has no notion of background location permission.
+    return false;
+  }
+
+  @override
   Future<bool> requestService() async {
     return true;
   }


### PR DESCRIPTION
## Summary

Adds `Location.isBackgroundPermissionGranted()` so apps can check whether the
"Allow all the time" / Always (background) location permission has been granted,
before calling `enableBackgroundMode` — enabling an in-app rationale dialog
instead of jumping straight to the system settings.

This is a **non-breaking** change: it adds a dedicated method rather than
altering the `PermissionStatus` enum (reordering/adding enum values would be a
breaking change for existing switch statements).

### Behaviour per platform
- **iOS / macOS**: returns `true` only when authorization is `.authorizedAlways`
  (`.authorizedWhenInUse` does not grant background access).
- **Android**: reflects the `ACCESS_BACKGROUND_LOCATION` runtime permission on
  API 29+ (Android 10). On older versions there is no separate background
  permission — foreground access already implies background — so it mirrors
  `hasPermission()`.
- **Web**: always `false` (no notion of background permission).

### Changes
- Dart: new method on `Location`, `LocationPlatform`, `MethodChannelLocation`,
  and the web implementation.
- iOS/macOS (`LocationPlugin.swift`): new `isBackgroundPermissionGranted` handler.
- Android (`FlutterLocation.kt` / `MethodCallHandlerImpl.kt`): new
  `checkBackgroundPermissions()` + handler.
- Tests added to `location_platform_interface` (default-throws + method-channel
  round trip).
- CHANGELOG entry under `## Unreleased`.

## Verification
- `dart format .` — clean (0 changed) in all three changed packages.
- `flutter analyze` — no issues in `location`, `location_platform_interface`,
  `location_web`.
- `flutter test` in `location_platform_interface` — all 29 tests pass
  (including the two new ones).
- iOS: `flutter build ios --simulator --no-codesign` — built successfully.
- Android: `flutter build apk --debug` — built successfully.

Fixes #538
