### PR TITLE
docs: getLastKnownLocation and isBackgroundPermissionGranted

### DIFF
--- a/docs/features/get-location.mdx
+++ b/docs/features/get-location.mdx
@@ -38,3 +38,30 @@ await location.changeSettings(accuracy: LocationAccuracy.high);
 final locationData = await location.getLocation();
 print("Location: ${locationData.latitude}, ${locationData.longitude}");
 ```
+
+## Last known location
+
+If you want to show something immediately instead of waiting for a fresh fix,
+you can read the location the platform has already cached:
+
+```dart
+Future<LocationData?> getLastKnownLocation()
+```
+
+Unlike `getLocation`, this returns right away without acquiring a new fix. It
+returns `null` when no cached location is available (for example on a fresh
+install). This is handy for displaying an approximate position — for instance a
+grey marker with its timestamp — while a precise location is still being
+acquired.
+
+```dart
+final location = Location();
+final cached = await location.getLastKnownLocation();
+if (cached != null) {
+    print("Last known: ${cached.latitude}, ${cached.longitude}");
+}
+// Meanwhile, request a precise fix.
+final fresh = await location.getLocation();
+```
+
+Web has no cached-location concept and always returns `null`.

--- a/docs/features/permissions.mdx
+++ b/docs/features/permissions.mdx
@@ -32,6 +32,32 @@ Future<PermissionStatus> requestPermission()
 A dialog will be shown to the user if the location has not been granted yet.
 If a reduced precision permission has been given (`PermissionStatus.grantedLimited`), the user will be asked to grant the precise permission.
 
+## Background Permission
+
+To keep receiving location updates while the app is in the background, the user
+must grant "Allow all the time" (Always) access on top of the foreground grant.
+You can check whether that has been granted with:
+
+```dart
+Future<bool> isBackgroundPermissionGranted()
+```
+
+Use it before calling `enableBackgroundMode` to decide whether to show an in-app
+rationale before sending the user to the system settings.
+
+- **iOS / macOS:** `true` only when the authorization status is "Always".
+- **Android:** reflects the `ACCESS_BACKGROUND_LOCATION` runtime permission on
+  API 29+ (Android 10). On older versions background access is implied by the
+  foreground grant, so this mirrors `hasPermission`.
+- **Web:** always `false`.
+
+```dart
+final location = Location();
+if (!await location.isBackgroundPermissionGranted()) {
+    // Show your own explanation, then guide the user to settings.
+}
+```
+
 ## Examples
 
 ### Getting permission status


### PR DESCRIPTION
Adds docs-site coverage for two methods that shipped without pages:

- **`getLastKnownLocation()`** → Get Location page. Returns the platform's
  cached location immediately (or `null`), useful to show an approximate
  position while a precise fix is acquired. Web returns `null`.
- **`isBackgroundPermissionGranted()`** → Permissions page. Reports whether
  "Allow all the time" / Always access has been granted, so apps can show a
  rationale before `enableBackgroundMode`. Documents the per-platform behaviour
  (iOS/macOS Always-only, Android `ACCESS_BACKGROUND_LOCATION` on API 29+, web
  always `false`).

Docs only — the methods themselves already merged. No code or changelog change.

## Verification

- Signatures checked against `packages/location/lib/location.dart` (not memory).