### PR TITLE
fix(android): don't report deniedForever on the first permission denial

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -40,6 +40,9 @@ private const val REQUEST_PERMISSIONS_REQUEST_CODE = 34
 private const val REQUEST_CHECK_SETTINGS = 0x1
 private const val GPS_ENABLE_REQUEST = 0x1001
 
+private const val PREFS_NAME = "flutter_location_prefs"
+private const val PREFS_KEY_PERMISSION_REQUESTED = "location_permission_requested"
+
 class FlutterLocation(
     applicationContext: Context,
     activity: Activity?,
@@ -110,6 +113,17 @@ class FlutterLocation(
 
     private val locationManager: LocationManager =
         applicationContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    private val sharedPreferences =
+        applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    // Whether the location permission had already been requested from this app
+    // before the request currently in flight. Captured right before calling
+    // ActivityCompat.requestPermissions() (#1009): shouldShowRequestPermissionRationale()
+    // returns false both before the permission has ever been asked for AND once
+    // it has been permanently denied, so it alone can't tell a first-time denial
+    // apart from "don't ask again". Persisted so it survives process death.
+    private var permissionPreviouslyRequested = false
 
     /**
      * Whether Google Play services (and therefore the fused location provider) is
@@ -185,7 +199,12 @@ class FlutterLocation(
                 result?.success(code)
                 result = null
             } else {
-                if (!shouldShowRequestPermissionRationale()) {
+                // shouldShowRequestPermissionRationale() returns false both before the
+                // permission has ever been requested and once it's permanently denied
+                // ("don't ask again"), so on its own it can't distinguish a first-time
+                // denial/dismissal from a real "never ask again" (#1009). Only treat it
+                // as permanently denied when we know a prior request already happened.
+                if (!shouldShowRequestPermissionRationale() && permissionPreviouslyRequested) {
                     sendError(
                         "PERMISSION_DENIED_NEVER_ASK",
                         "Location permission denied forever - please open app settings",
@@ -550,6 +569,9 @@ class FlutterLocation(
             result?.success(permissionStatusCode())
             return
         }
+        permissionPreviouslyRequested =
+            sharedPreferences.getBoolean(PREFS_KEY_PERMISSION_REQUESTED, false)
+        sharedPreferences.edit().putBoolean(PREFS_KEY_PERMISSION_REQUESTED, true).apply()
         ActivityCompat.requestPermissions(
             activity,
             arrayOf(


### PR DESCRIPTION
## Summary

**Fixes #1009** — `requestPermission()` reported `PermissionStatus.deniedForever` the very first time a user denied (or even just dismissed by tapping outside) the system location permission dialog, when it should have reported `denied` (matching `permission_handler`'s and the documented Android behavior).

Root cause: `ActivityCompat.shouldShowRequestPermissionRationale()` returns `false` in **two** distinct situations — before the permission has ever been requested, and once it's been permanently denied ("don't ask again"). The plugin's `onRequestPermissionsResult` used `!shouldShowRequestPermissionRationale()` alone to mean "permanently denied", conflating the two. This is a well-documented Android platform quirk, and is more pronounced when requesting `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION` together in a single call, as this plugin does.

Fix: persist (in `SharedPreferences`) whether the location permission has been requested before. `requestPermissions()` captures that flag right before issuing the request (and then marks it `true` for next time), and `onRequestPermissionsResult` only reports `deniedForever` when a prior request is actually known to have happened — otherwise it reports `denied`, giving the app a chance to ask again.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages.
- No Android unit test harness exists in this repo to exercise `FlutterLocation.kt` directly (there are no Kotlin/Java tests anywhere in the codebase), so this was verified by build + careful tracing of the Android permission-callback state machine against the documented `shouldShowRequestPermissionRationale()` semantics.