### PR TITLE
fix(ios): resolve getLocation() when a just-in-time permission request is denied

### DIFF
--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -436,6 +436,20 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
                 permissionWanted = false
                 flutterResult?(0)
                 flutterResult = nil
+            } else if locationWanted {
+                // getLocation() requested permission just-in-time (status was
+                // .notDetermined) and the user denied it. Without this, flutterResult
+                // was never resolved and the Dart Future from getLocation() hung
+                // forever instead of throwing, since only the requestPermission() flow
+                // above resolved on denial (#979).
+                locationWanted = false
+                flutterResult?(FlutterError(
+                    code: "PERMISSION_DENIED",
+                    message: "The user explicitly denied the use of location services for this app or "
+                        + "location services are currently disabled in Settings.",
+                    details: nil,
+                ))
+                flutterResult = nil
             }
             return
         }


### PR DESCRIPTION
## Summary

**Fixes #979** — on iOS/macOS, calling `getLocation()` while authorization is still `.notDetermined` triggers a just-in-time permission request. If the user denies that prompt, the Dart `Future` from `getLocation()` never completed at all (no value, no exception) — it just hung forever. The linked issue describes this as "no exception is thrown", but the actual behavior is worse: the call never returns.

Root cause, in `LocationPlugin.swift`'s `handleAuthorizationChange`:

```swift
if status == .denied {
    if permissionWanted {
        permissionWanted = false
        flutterResult?(0)
        flutterResult = nil
    }
    return
}
```

This only resolves `flutterResult` on denial when `permissionWanted` is set — i.e. only for the `requestPermission()` flow. `getLocation()` sets `locationWanted` instead (see `onGetLocation`), so when *that* flow's permission prompt comes back denied, this branch does nothing and `flutterResult` is left unresolved forever.

Fix: also resolve the `locationWanted` case here, with a `PERMISSION_DENIED` `FlutterError` — the same error `onGetLocation` already returns when authorization is already `.denied` before the call even starts (see the existing early-return a few lines above in the same file). This makes the just-in-time-denial path consistent with the already-denied path.

## Verification

- `flutter build ios --simulator --no-codesign` and `flutter build macos --debug` in `packages/location/example` — both build clean (this Swift source is shared between iOS and macOS via `sharedDarwinSource`).
- Reverted incidental `macos/Runner.xcodeproj` churn from the build so the diff is feature-only.
- Not runtime-reproduced end-to-end: simulating the just-in-time "user denies the system prompt" transition needs interactive UI automation (XCUITest) rather than a scriptable `xcrun simctl` state change, so this was verified by build + tracing the exact state-machine path against the existing (working) `permissionWanted` branch it mirrors, rather than an on-device repro.