### PR TITLE
fix(ios): report null instead of -1 for unavailable speed/speedAccuracy

### DIFF
--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -373,14 +373,23 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
             }
         }
 
+        // Core Location uses a negative value as a sentinel for "invalid/not
+        // available" on speed and speed accuracy (see the `CLLocation.speed`
+        // and `CLLocation.speedAccuracy` docs). Passed straight through, that
+        // sentinel reads to Dart callers as a real (negative) measurement
+        // rather than "no data", e.g. a stationary or indoor fix reporting a
+        // speed of exactly -1 (#741). Map it to `nil` instead.
+        let speed: Double? = location.speed >= 0 ? location.speed : nil
+        let speedAccuracy: Double? = location.speedAccuracy >= 0 ? location.speedAccuracy : nil
+
         return [
             "latitude": location.coordinate.latitude,
             "longitude": location.coordinate.longitude,
             "accuracy": location.horizontalAccuracy,
             "verticalAccuracy": location.verticalAccuracy,
             "altitude": location.altitude,
-            "speed": location.speed,
-            "speed_accuracy": location.speedAccuracy,
+            "speed": speed as Any,
+            "speed_accuracy": speedAccuracy as Any,
             "heading": location.course,
             "time": timeInMilliseconds,
             "isMock": isMock ? 1 : 0,


### PR DESCRIPTION
## Summary

**Fixes #741** — on iOS, `LocationData.speed`/`speedAccuracy` returned `-1` for an indoor/stationary fix instead of a real measurement, and the reporter expected changing position to produce sensible values.

Root cause: `CLLocation.speed` and `CLLocation.speedAccuracy` use a negative value as Apple's own documented sentinel meaning "invalid / not available" (e.g. no reliable velocity vector — indoors, stationary, or poor signal). `coordinates(from:)` passed that sentinel straight through into the map sent to Dart, so callers received a literal `-1.0` that looks like a real (if nonsensical) measurement rather than "no data".

Fix: map a negative `speed`/`speedAccuracy` to `nil` before building the result dictionary. `LocationData.speed`/`speedAccuracy` are already nullable `double?` fields on the Dart side (`location_platform_interface/lib/src/types.dart`), so this is a drop-in — no Dart-side changes needed.

## Verification

- `flutter build ios --simulator --no-codesign` and `flutter build macos --debug` in `packages/location/example` — both build clean (shared Darwin source).
- The fix relies on a Swift `Double?` `nil` boxed as `Any` bridging to `NSNull` (and therefore Dart `null`) when crossing the Objective-C-based `FlutterResult`/platform-channel boundary. Verified this specific bridging behavior in isolation with a standalone Swift script (`(nil as Double?) as Any` inside a `[String: Any]`, bridged to `NSDictionary`, resolves to `NSNull`) rather than assuming it.
- Reverted incidental `macos/Runner.xcodeproj` churn from the build so the diff is feature-only.
- Not reproduced end-to-end against a live indoor fix in this sandbox (no physical device/real GPS available here); verified via the build + the bridging check above instead.