### PR TITLE
fix(android): populate satelliteNumber from NMEA instead of a dead extras key

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -85,6 +85,12 @@ class FlutterLocation(
 
     private var mLastMslAltitude: Double? = null
 
+    // Number of satellites used in the last fix, parsed from NMEA (see
+    // createLocationCallback). Location.extras' "satellites" key is a legacy
+    // GPS-provider-only extra that the fused provider never populates, which
+    // made satelliteNumber always report 0 (#808).
+    private var mLastSatelliteCount: Int? = null
+
     // Parameters of the request
     private var updateIntervalMilliseconds = 5000L
     private var fastestUpdateIntervalMilliseconds = updateIntervalMilliseconds / 2
@@ -349,10 +355,16 @@ class FlutterLocation(
                         val tokens = message.split(",")
                         val type = tokens[0]
 
-                        // Parse altitude above sea level. Description of NMEA string:
+                        // Parse altitude above sea level and satellites used from the
+                        // GGA sentence. Description of NMEA string:
                         // http://aprs.gids.nl/nmea/#gga
-                        if (type.startsWith("\$GPGGA") && tokens.size > 9 && tokens[9].isNotEmpty()) {
-                            mLastMslAltitude = tokens[9].toDoubleOrNull()
+                        if (type.startsWith("\$GPGGA") && tokens.size > 9) {
+                            if (tokens[7].isNotEmpty()) {
+                                mLastSatelliteCount = tokens[7].toIntOrNull()
+                            }
+                            if (tokens[9].isNotEmpty()) {
+                                mLastMslAltitude = tokens[9].toDoubleOrNull()
+                            }
                         }
                     }
                 }
@@ -377,7 +389,13 @@ class FlutterLocation(
         }
 
         loc["provider"] = location.provider
-        location.extras?.let { loc["satelliteNumber"] = it.getInt("satellites") }
+        // The "satellites" extra is only ever set by the legacy GPS provider;
+        // the fused provider never populates it, so fall back to the NMEA-derived
+        // count (see createLocationCallback) which works for both (#808).
+        val satelliteCount =
+            location.extras?.takeIf { it.containsKey("satellites") }?.getInt("satellites")
+                ?: mLastSatelliteCount
+        satelliteCount?.let { loc["satelliteNumber"] = it }
 
         loc["elapsedRealtimeNanos"] = location.elapsedRealtimeNanos.toDouble()
         if (isLocationFromMockProvider(location)) {


### PR DESCRIPTION
## Summary

**Fixes #808** — `LocationData.satelliteNumber` always reported `0` on Android.

Root cause: it was read from `Location.extras.getInt("satellites")`. That `"satellites"` extra is a legacy key set only by the old GPS `LocationProvider` API — the `FusedLocationProviderClient` this plugin has used since the 9.0.0 Kotlin rewrite never populates it, so `extras` either has no such key (making `Bundle.getInt` fall back to its default of `0`) or `extras` itself is often present but unrelated.

Fix: the plugin already parses the `$GPGGA` NMEA sentence for MSL altitude via `OnNmeaMessageListener` (`createLocationCallback`). GGA's field 8 ("Satellites Used", `tokens[7]` after splitting on `,`) is the actual satellite-in-use count, sitting right next to the altitude field (`tokens[9]`) already being parsed. Track that field the same way, and prefer it in `locationToMap`, falling back to the extras key only if it's actually present (kept for any provider that does populate it).

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages.
- No Android unit test harness exists in this repo to exercise `FlutterLocation.kt` directly; verified by build + manually checking the GGA sentence field layout (field 8 = satellites used, field 10 = MSL altitude — matches the existing altitude-parsing code's own field-9 comment/reference) against the NMEA spec referenced in the existing code comment (http://aprs.gids.nl/nmea/#gga).