### PR TITLE
docs(readme): clarify background mode does not survive app termination

### DIFF
--- a/packages/location/README.md
+++ b/packages/location/README.md
@@ -164,6 +164,15 @@ requests the `ACCESS_BACKGROUND_LOCATION` permission when it has not been grante
 yet, so you can use it to prompt for background permission independently, without
 having to activate a location stream first.
 
+**This only keeps tracking location while your app process is alive** — on
+Android via a foreground service, on iOS via a background execution exemption.
+Neither survives the user manually killing the app (swiping it away from the
+recent-apps list) or the OS terminating it outright; there is no way for any
+Flutter plugin to run Dart code once the process itself no longer exists. If
+you need tracking that resumes after the app is killed/terminated, look at a
+plugin built around native background services designed for that, such as
+[`flutter_background_geolocation`](https://pub.dev/packages/flutter_background_geolocation).
+
 Be sure to check the example project to get other code samples.
 
 On Android, a foreground notification is displayed with information that location service is running in the background.


### PR DESCRIPTION
## Summary

The backlog groups 15 issues under "background/killed-app tracking", with a note recommending a README statement + bulk close. I went through all 15 individually rather than bulk-closing on the label alone, since several turned out to be a different bug entirely:

**Genuinely "doesn't survive app termination" requests — this PR's `Fixes` list:**
#707, #724, #773, #774, #888, #994, #1021, #1024, #1025 all ask for tracking/location access to keep working after the user/OS kills the app process (including via a headless callback like Firebase Messaging's background handler or `flutter_background_service`, which run without an Activity). That's not achievable by this plugin (or any Flutter plugin) — Android's foreground service and iOS's background execution exemption both require the app process to still be alive; once it's killed there's no Dart VM left to run anything. This PR adds an explicit README callout for that boundary and points to `flutter_background_geolocation` (built around native background services designed for post-termination tracking) as the alternative.

**NOT included — miscategorized under the same theme, each a distinct, still-open, unaddressed issue:**
- **#535** — `onLocationChanged` doesn't error when location services get disabled mid-stream. Real bug, unrelated to app termination.
- **#600** — feature request: support Android's "while in use" foreground-service exception instead of requiring full "Always" permission. Legitimate, unimplemented.
- **#924, #954** — background tracking silently stops on Android 13/14 specifically, while the app is still alive in the intended foreground-service mode (not killed). Possibly a real stricter-background-restrictions issue introduced by newer Android versions.
- **#950, #1012** — background tracking on iOS stops after ~10 minutes / ~2 hours while backgrounded (not killed). Possibly iOS background-execution-time-limit related.

I'd flag these six for separate investigation rather than closing them here — closing them under the "termination" umbrella would misrepresent what they're actually reporting.

## Verification

Docs-only change (README.md), no code touched.