### PR TITLE
fix(ios): recognize NSLocationAlwaysAndWhenInUseUsageDescription

### DIFF
--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -278,7 +278,12 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
 
     private func requestPermission() {
         let hasWhenInUse = Bundle.main.object(forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription") != nil
+        // NSLocationAlwaysUsageDescription is the pre-iOS 11 key; the modern,
+        // README-recommended key is NSLocationAlwaysAndWhenInUseUsageDescription.
+        // Only checking the old key meant an app declaring solely the current
+        // key was treated as having neither description (#962).
         let hasAlways = Bundle.main.object(forInfoDictionaryKey: "NSLocationAlwaysUsageDescription") != nil
+            || Bundle.main.object(forInfoDictionaryKey: "NSLocationAlwaysAndWhenInUseUsageDescription") != nil
 
         #if os(macOS)
         if hasWhenInUse || hasAlways {
@@ -296,7 +301,7 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
         #endif
 
         NSLog(
-            "[Location] Missing NSLocationWhenInUseUsageDescription (or NSLocationAlwaysUsageDescription) "
+            "[Location] Missing NSLocationWhenInUseUsageDescription (or NSLocationAlwaysAndWhenInUseUsageDescription) "
                 + "in Info.plist; the location permission cannot be requested.")
     }
 


### PR DESCRIPTION
## Summary

**Fixes #962** — `requestPermission()`'s internal `requestPermission()` (native, not the public Dart method) only checked `Info.plist` for the pre-iOS 11 `NSLocationAlwaysUsageDescription` key to decide whether it's allowed to call `requestAlwaysAuthorization()`. It never checked `NSLocationAlwaysAndWhenInUseUsageDescription` — the modern key Apple has required since iOS 11, and the one this plugin's own README recommends adding.

Concretely: an app that follows Apple's current guidance and declares only `NSLocationAlwaysAndWhenInUseUsageDescription` (without also adding the legacy `NSLocationAlwaysUsageDescription`) was treated by this check as having *no* always-usage description at all. If it also has no `NSLocationWhenInUseUsageDescription`, `requestPermission()` falls through to an `NSLog` warning and never prompts the user at all.

Fix: `hasAlways` now checks both keys.

## Verification

- `flutter build ios --simulator --no-codesign` and `flutter build macos --debug` in `packages/location/example` — both build clean (shared Darwin source).
- Reverted incidental `macos/Runner.xcodeproj` churn from the build so the diff is feature-only.
- Not runtime-reproduced (would need an Info.plist variant with only the modern key and a physical/simulator permission-prompt walkthrough); verified by tracing the exact `Bundle.main.object(forInfoDictionaryKey:)` check the issue points at, against Apple's documented `Info.plist` keys.