### PR TITLE
fix(android): error the location stream when the service gets disabled

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -22,6 +22,7 @@ import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.ResolvableApiException
 import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationAvailability
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
@@ -157,7 +158,15 @@ class FlutterLocation(
 
             override fun onProviderEnabled(provider: String) {}
 
-            override fun onProviderDisabled(provider: String) {}
+            override fun onProviderDisabled(provider: String) {
+                // Only surface an error once every provider is gone (checkServiceEnabled
+                // is the same OR-of-providers check used elsewhere); disabling just GPS
+                // while network location is still on shouldn't error out an active
+                // stream (#535).
+                if (!checkServiceEnabled()) {
+                    sendError("SERVICE_STATUS_DISABLED", "Location services were disabled", null)
+                }
+            }
         }
 
     val mapFlutterAccuracy: Map<Int, Int> =
@@ -336,6 +345,17 @@ class FlutterLocation(
         mLocationCallback?.let { mFusedLocationClient?.removeLocationUpdates(it) }
         mLocationCallback =
             object : LocationCallback() {
+                override fun onLocationAvailability(locationAvailability: LocationAvailability) {
+                    // isLocationAvailable can be false transiently (e.g. no fix yet,
+                    // temporarily indoors) without the location service actually being
+                    // disabled, so cross-check with checkServiceEnabled() -- the
+                    // deterministic "is the system location toggle off" signal -- before
+                    // erroring out an active stream (#535).
+                    if (!locationAvailability.isLocationAvailable && !checkServiceEnabled()) {
+                        sendError("SERVICE_STATUS_DISABLED", "Location services were disabled", null)
+                    }
+                }
+
                 override fun onLocationResult(locationResult: LocationResult) {
                     val location = locationResult.lastLocation ?: return
                     onNewLocation(location)


### PR DESCRIPTION
## Summary

**Fixes #535** — `onLocationChanged` gave no signal when location services were manually disabled while a stream was active; it just silently stopped emitting.

Root cause: neither Android location path overrode the callback that reports this.
- The fused provider's `LocationCallback` only overrode `onLocationResult`, never `onLocationAvailability` (which Play services calls whenever availability changes).
- The framework `LocationManager` fallback's `onProviderDisabled` was an empty no-op.

Fix: both now call the existing `sendError("SERVICE_STATUS_DISABLED", ...)` helper (already used elsewhere for this exact error code) — but only after cross-checking `checkServiceEnabled()` (the same deterministic "is the system location toggle actually off" check already used by `serviceEnabled()`/`requestService()`), not just trusting the raw signal alone:
- `LocationAvailability.isLocationAvailable` can be `false` transiently (no fix yet, temporarily indoors/tunnel) without the service being disabled at all — erroring on that alone would misfire on ordinary signal loss.
- `onProviderDisabled` fires per-provider; disabling GPS while network location is still on shouldn't error out an active stream, since `checkServiceEnabled()` is an OR across providers pre-Android-10.

This gives the app a clear signal (a stream error) to react to — e.g. prompt the user to re-enable location or call `requestService()` again — without spuriously erroring on normal signal gaps.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages.
- No Android unit test harness exists in this repo to exercise `FlutterLocation.kt` directly; verified by build + tracing that `sendError` (existing helper) doesn't stop the underlying `requestLocationUpdates` registration, so if the app reacts to the error by calling `onLocationChanged.listen(...)` again, `StreamHandlerImpl.onListen` re-attaches the event sink and re-requests updates cleanly — confirmed by reading that path, not runtime-reproduced (would need a physical device with a real location-services toggle).