### PR TITLE
docs(settings): clarify pausesLocationUpdatesAutomatically fixes unpredictable background stops

### DIFF
--- a/docs/features/settings.mdx
+++ b/docs/features/settings.mdx
@@ -40,6 +40,15 @@ When you call `changeSettings`, an active `onLocationChanged` stream is updated 
 is backgrounded, then resume the foreground `interval` automatically. It is
 Android-only — Core Location has no equivalent on iOS/macOS.
 
+If you need continuous background tracking on iOS/macOS and see updates stop
+unexpectedly after some time (the exact duration varies — it depends on the
+device's movement, not a fixed timeout), set
+`pausesLocationUpdatesAutomatically: false`. Core Location's default (`true`)
+lets it pause updates on its own judgment — e.g. when the device appears to
+have stopped moving — as a battery-saving heuristic, which is usually fine but
+can be surprising for an app that expects truly continuous updates (like live
+tracking).
+
 ## Example
 
 ```dart


### PR DESCRIPTION
## Summary

Possibly related to **#950** and **#1012** — both report iOS background location tracking stopping after some time (~10 minutes in one report, ~2 hours in the other). The inconsistent duration is the tell: this isn't a fixed OS background-execution timeout, it's `CLLocationManager.pausesLocationUpdatesAutomatically` (which this plugin sets to `true` by default) letting Core Location pause updates on its own judgment — typically when the device appears to have stopped moving — as a battery-saving heuristic.

The fix already exists via the public API — `changeSettings(pausesLocationUpdatesAutomatically: false)` — it just wasn't connected to this specific "background tracking stops unpredictably" symptom anywhere in the docs, so users hitting it had no way to find it.

Not claiming `Fixes` for #950/#1012 since I can't confirm this is their exact root cause without the reporters testing it, but flagging both as "possibly related, not auto-closed" per the PR conventions here.

## Verification

Docs-only change (`docs/features/settings.mdx`), no code touched.