### PR TITLE
fix(android): resolve getLocation() when the settings-resolution dialog is cancelled

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -251,13 +251,19 @@ class FlutterLocation(
                 return true
             }
             REQUEST_CHECK_SETTINGS -> {
-                val result = this.result ?: return false
+                // This resolution dialog is triggered by startRequestingLocation(), on
+                // behalf of a pending getLocation() one-shot call and/or an active
+                // onLocationChanged stream -- getLocationResult/events, not the
+                // requestPermission()-only `result` field this used to (incorrectly)
+                // check, which is virtually always null here. Checking the wrong field
+                // meant getLocation() hung forever if the user cancelled this dialog,
+                // since neither field was ever resolved (#728, #1020).
+                if (getLocationResult == null && events == null) return false
                 if (resultCode == Activity.RESULT_OK) {
                     startRequestingLocation()
                     return true
                 }
-                result.error("SERVICE_STATUS_DISABLED", "Failed to get location. Location services disabled", null)
-                this.result = null
+                sendError("SERVICE_STATUS_DISABLED", "Failed to get location. Location services disabled", null)
                 return true
             }
             else -> return false


### PR DESCRIPTION
## Summary

**Possibly related to #728** (crash: `IllegalStateException: Reply already submitted` in the old pre-Kotlin `FlutterLocation.onActivityResult`) **and #1020** (`SERVICE_STATUS_ERROR` PlatformException with no useful detail) — not claiming `Fixes` for either since I can't fully confirm they're this exact root cause from the reports alone, but this is a real, independently-confirmed bug in the current code.

`onActivityResult`'s `REQUEST_CHECK_SETTINGS` case is reached when `startRequestingLocation()` (called from `getLocation()`, the location stream, or `changeSettings()`) triggers Google Play Services' "enable location settings" resolution dialog, and the user responds to it. It used to check `this.result` to know whether to report a cancellation:

```kotlin
REQUEST_CHECK_SETTINGS -> {
    val result = this.result ?: return false
    ...
    result.error("SERVICE_STATUS_DISABLED", ...)
```

But `result` is populated *only* by `requestPermission()` (`MethodCallHandlerImpl.kt:165`, `location.result = result`) — `getLocation()` and the stream use separate fields (`getLocationResult`, `events`) that `onActivityResult` never touched. In the normal case where no `requestPermission()` call is concurrently in flight, `result` is `null`, so `val result = this.result ?: return false` returns immediately and does nothing — meaning if a user cancels the "enable location settings" dialog that `getLocation()` itself triggered, **`getLocationResult` is never resolved and the Dart `Future` hangs forever** instead of throwing. An active `onLocationChanged` stream gets no signal either.

Fix: check `getLocationResult`/`events` (whichever is actually pending) instead, and report the cancellation through the existing `sendError()` helper — the same one already used everywhere else in this file for a disabled-service error.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages.
- No Android unit test harness exists in this repo to exercise `FlutterLocation.kt` directly; verified by tracing every assignment site of the `result` field (`grep` confirms it's set only in the `requestPermission()` path) against the fields actually used by `getLocation()`/the stream, confirming the field mismatch. Not runtime-reproduced (would need a physical device to trigger and cancel the real Play Services settings-resolution dialog).