### PR TITLE
fix(ios): honor changeSettings' interval by throttling stream delivery

### DIFF
--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -24,6 +24,15 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     // locationManager(_:didUpdateLocations:).
     private let staleLocationThreshold: TimeInterval = 15
 
+    // Core Location has no native "minimum time between updates" concept (only
+    // distanceFilter, a minimum distance) unlike Android's LocationRequest
+    // interval, so `interval` was silently ignored on iOS/macOS and the stream
+    // fired as fast as fixes arrived (#960). Throttled client-side instead: the
+    // stream drops updates delivered sooner than this many milliseconds after
+    // the last one it forwarded. Matches the Dart-side default of 1000ms.
+    private var updateIntervalMilliseconds: Double = 1000
+    private var lastStreamUpdateAt: Date?
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         #if os(iOS)
         let messenger = registrar.messenger()
@@ -131,6 +140,10 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
 
             let distanceFilter = args["distanceFilter"] as? Double ?? 0
             manager.distanceFilter = distanceFilter == 0 ? kCLDistanceFilterNone : distanceFilter
+
+            if let interval = args["interval"] as? Int {
+                self.updateIntervalMilliseconds = Double(interval)
+            }
 
             if let pauses = args["pausesLocationUpdatesAutomatically"] as? Bool {
                 manager.pausesLocationUpdatesAutomatically = pauses
@@ -341,6 +354,7 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     public func onListen(withArguments _: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         flutterEventSink = events
         flutterListening = true
+        lastStreamUpdateAt = nil
 
         if isPermissionGranted {
             clLocationManager?.startUpdatingLocation()
@@ -427,6 +441,12 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
             flutterResult = nil
         }
         if flutterListening {
+            let now = Date()
+            if let lastUpdate = lastStreamUpdateAt,
+               now.timeIntervalSince(lastUpdate) * 1000 < updateIntervalMilliseconds {
+                return
+            }
+            lastStreamUpdateAt = now
             flutterEventSink?(coordinates)
         } else {
             clLocationManager?.stopUpdatingLocation()


### PR DESCRIPTION
## Summary

**Fixes #960** — `changeSettings(interval: ...)` had no effect on iOS/macOS; `onLocationChanged` fired as fast as Core Location delivered fixes, ignoring the configured interval entirely.

Root cause: `onChangeSettings` never read the `interval` argument at all. Unlike Android's `LocationRequest`, which has an explicit time-based `interval`, Core Location has no equivalent concept — only `distanceFilter` (a minimum distance between updates). There's nothing to forward `interval` to.

Fix: throttle client-side. Track when the stream last forwarded an update to Dart, and drop (don't forward) an update arriving sooner than `interval` milliseconds after the last one. This only applies to the continuous stream — a pending one-shot `getLocation()` call still resolves on the very next update regardless of the throttle, and the throttle timestamp resets on every new `onListen` so a stale value from a previous subscription can't delay the first update of a fresh one.

## Verification

- `flutter build ios --simulator --no-codesign` and `flutter build macos --debug` in `packages/location/example` — both build clean (shared Darwin source).
- Reverted incidental `macos/Runner.xcodeproj` churn from the build so the diff is feature-only.
- Not runtime-reproduced against a live rapid-update GPS stream in this sandbox; verified by tracing the exact elapsed-time comparison against `Date`/`TimeInterval` semantics, and confirming the default (`1000`ms) matches the Dart-side default in `location_platform_interface`'s `changeSettings`.