### PR TITLE
fix(android,ios): resolve all concurrent getLocation() calls, not just the last

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -115,8 +115,12 @@ class FlutterLocation(
     // Store the result for the requestService, used in ActivityResult
     private var requestServiceResult: Result? = null
 
-    // Store result until a location is getting resolved
-    var getLocationResult: Result? = null
+    // Pending getLocation() calls waiting for the next fix. A list rather than
+    // a single field: overwriting a single pending Result silently orphaned an
+    // earlier concurrent getLocation() call's Future forever when a second one
+    // came in before the first resolved (#977). All pending calls resolve
+    // together with the same fix/error.
+    val getLocationResults: MutableList<Result> = mutableListOf()
 
     private val locationManager: LocationManager =
         applicationContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -200,7 +204,7 @@ class FlutterLocation(
             if (fineGranted || coarseGranted) {
                 // Either precise or approximate location was granted.
                 // Checks if this permission was automatically triggered by a location request
-                if (getLocationResult != null || events != null) {
+                if (getLocationResults.isNotEmpty() || events != null) {
                     startRequestingLocation()
                 }
                 // Approximate-only (coarse without fine) on Android 12+ maps to
@@ -314,8 +318,8 @@ class FlutterLocation(
         errorMessage: String,
         errorDetails: Any?,
     ) {
-        getLocationResult?.error(errorCode, errorMessage, errorDetails)
-        getLocationResult = null
+        getLocationResults.forEach { it.error(errorCode, errorMessage, errorDetails) }
+        getLocationResults.clear()
         events?.error(errorCode, errorMessage, errorDetails)
         events = null
     }
@@ -329,8 +333,8 @@ class FlutterLocation(
     private fun onNewLocation(location: Location) {
         val loc = locationToMap(location)
 
-        getLocationResult?.success(loc)
-        getLocationResult = null
+        getLocationResults.forEach { it.success(loc) }
+        getLocationResults.clear()
         val events = this.events
         if (events != null) {
             events.success(loc)

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
@@ -113,7 +113,7 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
         result: Result,
         location: FlutterLocation,
     ) {
-        location.getLocationResult = result
+        location.getLocationResults.add(result)
         if (!location.checkPermissions()) {
             location.requestPermissions()
         } else {

--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -13,7 +13,12 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     private var flutterResult: FlutterResult?
     private var flutterEventSink: FlutterEventSink?
 
-    private var locationWanted = false
+    // Pending getLocation() calls waiting for the next fix. A list rather than
+    // a single field: overwriting a single pending result silently orphaned an
+    // earlier concurrent getLocation() call's Future forever when a second one
+    // came in before the first resolved (#977). All pending calls resolve
+    // together with the same fix/error.
+    private var pendingLocationResults: [FlutterResult] = []
     private var permissionWanted = false
     private var flutterListening = false
     private var hasInit = false
@@ -187,8 +192,7 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
                 return
             }
 
-            self.flutterResult = result
-            self.locationWanted = true
+            self.pendingLocationResults.append(result)
 
             if self.isPermissionGranted {
                 self.clLocationManager?.startUpdatingLocation()
@@ -421,10 +425,9 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
 
         let coordinates = coordinates(from: location)
 
-        if locationWanted {
-            locationWanted = false
-            flutterResult?(coordinates)
-            flutterResult = nil
+        if !pendingLocationResults.isEmpty {
+            pendingLocationResults.forEach { $0(coordinates) }
+            pendingLocationResults.removeAll()
         }
         if flutterListening {
             flutterEventSink?(coordinates)
@@ -450,20 +453,20 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
                 permissionWanted = false
                 flutterResult?(0)
                 flutterResult = nil
-            } else if locationWanted {
+            } else if !pendingLocationResults.isEmpty {
                 // getLocation() requested permission just-in-time (status was
-                // .notDetermined) and the user denied it. Without this, flutterResult
-                // was never resolved and the Dart Future from getLocation() hung
-                // forever instead of throwing, since only the requestPermission() flow
-                // above resolved on denial (#979).
-                locationWanted = false
-                flutterResult?(FlutterError(
+                // .notDetermined) and the user denied it. Without this, the pending
+                // result(s) were never resolved and the Dart Future(s) from
+                // getLocation() hung forever instead of throwing, since only the
+                // requestPermission() flow above resolved on denial (#979).
+                let error = FlutterError(
                     code: "PERMISSION_DENIED",
                     message: "The user explicitly denied the use of location services for this app or "
                         + "location services are currently disabled in Settings.",
                     details: nil,
-                ))
-                flutterResult = nil
+                )
+                pendingLocationResults.forEach { $0(error) }
+                pendingLocationResults.removeAll()
             }
             return
         }
@@ -482,7 +485,7 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
             flutterResult?(isHighAccuracyPermitted ? 1 : 3)
             flutterResult = nil
         }
-        if locationWanted || flutterListening {
+        if !pendingLocationResults.isEmpty || flutterListening {
             clLocationManager?.startUpdatingLocation()
         }
     }


### PR DESCRIPTION
## Summary

**Fixes #977** — calling `getLocation()` twice concurrently (e.g. two `FutureBuilder`s in the same build, both awaiting their own `location.getLocation()` call) only ever resolved the second one; the first's `Future` hung forever.

Root cause, on both platforms: the pending native `Result`/`FlutterResult` for `getLocation()` was stored in a single field (`getLocationResult` on Android, `flutterResult` + `locationWanted` on iOS/macOS). A second concurrent call overwrote that field before the first one resolved, silently orphaning the first call's callback — nothing ever completed it.

Fix: both platforms now queue pending `getLocation()` results in a list (`getLocationResults` on Android, `pendingLocationResults` on iOS/macOS) instead of a single field, and resolve *all* of them together the next time a fix (or an applicable error) arrives — matching what a caller issuing several concurrent one-shot requests would actually expect, and what the reporter's exact repro (two simultaneous `FutureBuilder`s) needs.

The iOS/macOS `locationWanted` boolean is removed entirely — it's now equivalent to `!pendingLocationResults.isEmpty`, so there's no separate flag that could drift out of sync with the list.

## Verification

- `flutter build apk --debug`, `flutter build ios --simulator --no-codesign`, and `flutter build macos --debug` in `packages/location/example` — all three build clean.
- `melos run analyze` — 0 issues across all packages.
- Reverted incidental `macos/Runner.xcodeproj` churn from the build so the diff is feature-only.
- No Android/iOS unit test harness exists in this repo to exercise these files directly; verified by tracing every read/write site of the affected fields on both platforms (confirmed no other code path still reads the old single-field names) and by re-deriving the reporter's exact repro (two concurrent `getLocation()` calls) against the new list-based resolution logic. Not runtime-reproduced on a physical device.