### PR TITLE
fix(android): fix master build breakage from a cross-PR field rename miss

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -262,7 +262,7 @@ class FlutterLocation(
                 // check, which is virtually always null here. Checking the wrong field
                 // meant getLocation() hung forever if the user cancelled this dialog,
                 // since neither field was ever resolved (#728, #1020).
-                if (getLocationResult == null && events == null) return false
+                if (getLocationResults.isEmpty() && events == null) return false
                 if (resultCode == Activity.RESULT_OK) {
                     startRequestingLocation()
                     return true


### PR DESCRIPTION
## ⚠️ Urgent: `master` currently does not compile

## Summary

PR #1076 (merged) added a check on `getLocationResult` (the old singular field name) inside `FlutterLocation.onActivityResult`'s `REQUEST_CHECK_SETTINGS` case. PR #1078 (merged separately, branched from an earlier `master` before #1076 landed) renamed that field to a plural `getLocationResults` list everywhere it was used at the time — but #1078's branch didn't yet contain #1076's new reference, so it couldn't have updated it. Both PRs individually passed CI (each tested only its own branch's diff against `master` at PR-open time), but the *combination*, once both merged, left an unresolved reference and a broken build. This repo's CI only runs on `pull_request` events, never re-verifying `master` itself after a merge, so nothing caught this until now.

Fix: update the one remaining reference to use the current field.

## Verification

- Confirmed the break: `flutter build apk --debug` in `packages/location/example` against current `master` fails with `Unresolved reference 'getLocationResult'` at `FlutterLocation.kt:265`.
- Applied the fix, same build now succeeds.
- `melos run analyze` — 0 issues.