### PR TITLE
fix(android): catch startForeground() failures instead of crashing

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocationService.kt
@@ -259,26 +259,40 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
 
     fun isInForegroundMode(): Boolean = isForeground
 
-    fun enableBackgroundMode() {
+    /**
+     * Starts the service in foreground mode. Returns whether it succeeded:
+     * on Android 12+ the system can refuse a foreground service start (e.g.
+     * `ForegroundServiceStartNotAllowedException` when the app has no
+     * qualifying foreground-launch exemption at the time of the call), which
+     * previously crashed with an unhandled exception instead of surfacing a
+     * normal Dart-side error (#945).
+     */
+    fun enableBackgroundMode(): Boolean {
         if (isForeground) {
             Log.d(TAG, "Service already in foreground mode.")
-        } else {
-            Log.d(TAG, "Start service in foreground mode.")
-
-            val notification = backgroundNotification!!.build()
-            val foregroundServiceType =
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
-                } else {
-                    0
-                }
-            ServiceCompat.startForeground(this, ONGOING_NOTIFICATION_ID, notification, foregroundServiceType)
-
-            isForeground = true
-
-            // Switch to the background update interval, if one was configured.
-            location?.setBackgroundMode(true)
+            return true
         }
+        Log.d(TAG, "Start service in foreground mode.")
+
+        val notification = backgroundNotification!!.build()
+        val foregroundServiceType =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+            } else {
+                0
+            }
+        try {
+            ServiceCompat.startForeground(this, ONGOING_NOTIFICATION_ID, notification, foregroundServiceType)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start service in foreground mode.", e)
+            return false
+        }
+
+        isForeground = true
+
+        // Switch to the background update interval, if one was configured.
+        location?.setBackgroundMode(true)
+        return true
     }
 
     fun disableBackgroundMode() {
@@ -321,8 +335,11 @@ class FlutterLocationService : Service(), PluginRegistry.RequestPermissionsResul
         ) {
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
                 // Permissions granted, background mode can be enabled
-                enableBackgroundMode()
-                result?.success(1)
+                if (enableBackgroundMode()) {
+                    result?.success(1)
+                } else {
+                    result?.error("ENABLE_BACKGROUND_MODE_ERROR", "Failed to start the foreground service", null)
+                }
                 result = null
             } else {
                 if (!shouldShowRequestBackgroundPermissionRationale()) {

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
@@ -184,8 +184,11 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
         if (locationService != null && enable != null) {
             if (locationService.checkBackgroundPermissions()) {
                 if (enable) {
-                    locationService.enableBackgroundMode()
-                    result.success(1)
+                    if (locationService.enableBackgroundMode()) {
+                        result.success(1)
+                    } else {
+                        result.error("ENABLE_BACKGROUND_MODE_ERROR", "Failed to start the foreground service", null)
+                    }
                 } else {
                     locationService.disableBackgroundMode()
                     result.success(0)


### PR DESCRIPTION
## Summary

**Fixes #945, #961** — both are the exact same crash: `enableBackgroundMode()` crashed with an unhandled `ForegroundServiceStartNotAllowedException` (Android 12+) instead of a normal Dart-side error, when `ServiceCompat.startForeground()` was refused because the app had no qualifying foreground-launch exemption at that exact moment. (#961's stack trace is byte-for-byte the same failure, just through an obfuscated/minified release build.)

`FlutterLocationService.enableBackgroundMode()` called `ServiceCompat.startForeground(...)` with no error handling at all. Fix: it now returns whether the start actually succeeded (catching any exception from the system call), and both call sites — the direct `enableBackgroundMode(enable: true)` request and the one that runs right after a background-permission grant — report an `ENABLE_BACKGROUND_MODE_ERROR` `PlatformException` on failure instead of letting the exception propagate as a crash.

**⚠️ Note on CI:** this branch is based on `master` from before #1079 (the master-build-breakage hotfix) merges, so its own CI run may show red for an unrelated reason (the `getLocationResult`/`getLocationResults` build break #1079 fixes) until that lands and this gets rebased/re-run.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean (verified against master with #1079's one-line fix applied locally, then reverted before committing, to isolate this diff to just the intended fix).
- `melos run analyze` — 0 issues across all packages.
- No Android unit test harness exists in this repo to exercise `FlutterLocationService.kt` directly; verified by tracing both call sites of `enableBackgroundMode()` to confirm neither silently drops the new return value.