### PR TITLE
docs(notification): warn about release-build resource shrinking stripping icons

### DIFF
--- a/docs/features/notification.mdx
+++ b/docs/features/notification.mdx
@@ -27,6 +27,23 @@ It should be in the `res/drawable` folder with the same name. By default, the li
 "large icon"). Like `iconName`, it resolves a drawable in `res/drawable` by name.
 Leave it `null` (the default) for no image. Android only.
 
+Both are resolved at runtime by *name* (`Resources.getIdentifier`), not by a
+compile-time reference. Android's release-build resource shrinker only sees
+resources referenced directly in code/XML, so it can strip a drawable that's
+only ever looked up by its string name — showing up as a blank/transparent
+icon in release builds while working fine in debug. If that happens, tell the
+shrinker to keep it by adding a `res/raw/keep.xml` to your Android app:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/your_icon_name,@drawable/your_image_name" />
+```
+
+See Android's [shrink, obfuscate, and optimize your
+app](https://developer.android.com/build/shrink-code#keep-resources) guide for
+details.
+
 ## Examples
 
 ### Updating the notification with the current location


### PR DESCRIPTION
## Summary

**Possibly related to #839** (not claiming `Fixes` — it's a docs-only mitigation for a real Android build-tooling gotcha, not a code fix, but it directly explains and resolves the reported symptom).

#839 reports a blank/transparent icon in the Android background-location notification, but only in release builds — debug works fine. Root cause: `changeNotificationOptions`' `iconName`/`imageName` resolve drawables by *string name* at runtime (`Resources.getIdentifier`, see `FlutterLocationService.kt`'s `getDrawableId`). Android's release-build resource shrinker only tracks resources referenced directly in code/XML — a drawable that's only ever looked up dynamically by name looks "unused" to it and gets stripped from the release APK, exactly matching "works in debug, blank in release."

This isn't something the plugin can fix in code (the shrinker runs in the *consuming app's* build, not this plugin's); the standard mitigation is a `res/raw/keep.xml` `tools:keep` entry in the app telling the shrinker to keep the specific drawables. Documented that.

## Verification

Docs-only change (`docs/features/notification.mdx`), no code touched.