### PR TITLE
feat!: make LocationData.latitude/longitude non-nullable

### DIFF
--- a/packages/location/test/location_test.dart
+++ b/packages/location/test/location_test.dart
@@ -50,8 +50,8 @@ void main() {
   );
 
   test('getLocation should call the correct underlying instance', () async {
-    when(location.getLocation())
-        .thenAnswer((_) => Future.value(LocationData.fromMap({})));
+    when(location.getLocation()).thenAnswer((_) => Future.value(
+        LocationData.fromMap({'latitude': 42.0, 'longitude': 2.0})));
 
     await location.getLocation();
     verify(mockLocation.getLocation()).called(1);
@@ -60,8 +60,8 @@ void main() {
   test(
     'getLastKnownLocation should call the correct underlying instance',
     () async {
-      when(location.getLastKnownLocation())
-          .thenAnswer((_) => Future.value(LocationData.fromMap({})));
+      when(location.getLastKnownLocation()).thenAnswer((_) => Future.value(
+          LocationData.fromMap({'latitude': 42.0, 'longitude': 2.0})));
 
       await location.getLastKnownLocation();
       verify(mockLocation.getLastKnownLocation()).called(1);

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -24,8 +24,8 @@ class LocationData {
   /// Creates a new [LocationData] instance from a map.
   factory LocationData.fromMap(Map<String, dynamic> dataMap) {
     return LocationData._(
-      dataMap['latitude'] as double?,
-      dataMap['longitude'] as double?,
+      dataMap['latitude'] as double,
+      dataMap['longitude'] as double,
       dataMap['accuracy'] as double?,
       dataMap['altitude'] as double?,
       dataMap['speed'] as double?,
@@ -47,8 +47,8 @@ class LocationData {
   /// [toJson]. This round-trips with [toJson].
   factory LocationData.fromJson(Map<String, dynamic> json) {
     return LocationData._(
-      (json['latitude'] as num?)?.toDouble(),
-      (json['longitude'] as num?)?.toDouble(),
+      (json['latitude'] as num).toDouble(),
+      (json['longitude'] as num).toDouble(),
       (json['accuracy'] as num?)?.toDouble(),
       (json['altitude'] as num?)?.toDouble(),
       (json['speed'] as num?)?.toDouble(),
@@ -67,10 +67,10 @@ class LocationData {
   }
 
   /// Latitude in degrees
-  final double? latitude;
+  final double latitude;
 
   /// Longitude, in degrees
-  final double? longitude;
+  final double longitude;
 
   /// Estimated horizontal accuracy of this location, radial, in meters
   ///

--- a/packages/location_platform_interface/test/types_test.dart
+++ b/packages/location_platform_interface/test/types_test.dart
@@ -133,7 +133,12 @@ void main() {
     });
 
     test('fromJson(toJson) round-trips with null fields', () {
-      final locationData = LocationData.fromJson(<String, dynamic>{});
+      // latitude/longitude are non-nullable, so they're the only fields that
+      // must be present; everything else round-trips through its null default.
+      final locationData = LocationData.fromJson(<String, dynamic>{
+        'latitude': 42.0,
+        'longitude': 2.0,
+      });
 
       expect(LocationData.fromJson(locationData.toJson()), locationData);
     });


### PR DESCRIPTION
## ⚠️ Breaking change — needs a deliberate call on timing/versioning

## Summary

**Addresses #675** — `LocationData.latitude`/`longitude` are declared nullable even though every real location fix always has coordinates. The reporter's point stands: "It is not safe to just declare every possible field as null everywhere."

Checked all six platform implementations (Android, iOS/macOS, web, Windows, Linux) — every one unconditionally sets `latitude`/`longitude` in the map it hands back; none ever omit them. So the nullability was never load-bearing for real usage, just a static-typing tax on every caller.

**Why this is safer than a typical breaking change:** `LocationData` has a *private* constructor — nothing outside this package can construct one directly. That means:
- Existing code reading `data.latitude` and null-checking it still compiles fine (the check just becomes redundant/an analyzer hint, not an error).
- Assigning `data.latitude` to a `double?`-typed variable elsewhere still compiles fine (widening is always allowed).
- The only actual behavior change: `LocationData.fromMap()`/`fromJson()` now *throw* if given a map missing `latitude`/`longitude` (e.g. a hand-rolled test double), instead of silently producing a `LocationData` with null coordinates. Real platform code is unaffected since it never produces such a map.

I'm still marking this `feat!`/BREAKING CHANGE per semver convention for any narrowing of a public field's type, since I can't fully rule out how someone's code depends on the type signature (e.g. a generic wrapper), even though I could not find a single in-repo usage (own tests, docs, README, example app) that relies on the nullability. **Given the low real-world impact, whether this ships as part of the next version or gets held for a dedicated major bump is a call for you to make** — happy to adjust the changelog/version placement however you'd like.

## Verification

- `flutter test` in `location_platform_interface` (37 tests) and `location` (11 tests) — all pass (had to update two tests/fixtures that constructed a `LocationData` without coordinates).
- `melos run analyze` — 0 issues across all packages.
- `flutter build apk --debug` and `flutter build ios --simulator --no-codesign` in `packages/location/example` — both build clean.
- `dart format . --set-exit-if-changed` — clean.
- Grepped the whole repo (own lib code, docs, README, example) for any `latitude`/`longitude` null-check pattern — found none, confirming the nullability wasn't relied on anywhere in this codebase either.