### PR TITLE
docs(notification): document posting fully custom notification content

### DIFF
--- a/docs/features/notification.mdx
+++ b/docs/features/notification.mdx
@@ -67,3 +67,34 @@ _locationSubscription = location.onLocationChanged
 
 _locationSubscription?.cancel();
 ```
+
+### Fully custom notification content
+
+`changeNotificationOptions` covers the common fields, but Android identifies
+the foreground service's notification purely by its channel and notification
+ID — any code that posts to that same ID replaces its displayed content, the
+same way this plugin's own updates do internally. Call
+`changeNotificationOptions` once to obtain that ID, then use another
+notification plugin (e.g.
+[`flutter_local_notifications`](https://pub.dev/packages/flutter_local_notifications))
+to post whatever content you want to it:
+
+```dart
+final notificationData = await location.changeNotificationOptions();
+if (notificationData != null) {
+  await flutterLocalNotificationsPlugin.show(
+    notificationData.notificationId,
+    'Fully custom title',
+    'Fully custom body, any layout flutter_local_notifications supports',
+    NotificationDetails(
+      android: AndroidNotificationDetails(
+        notificationData.channelId,
+        'My channel name',
+      ),
+    ),
+  );
+}
+```
+
+Note that calling `changeNotificationOptions` again afterwards will overwrite
+your custom content back to this plugin's own notification builder.


### PR DESCRIPTION
## Summary

**Possibly related to #753, #928** (not claiming `Fixes` — this documents an existing capability/workaround rather than adding new plugin API, so it's the human's call whether it's enough to close either).

Both issues ask for a way to fully replace or disable this plugin's background-location notification with custom content (via another notification plugin like `awesome_notifications`/`flutter_local_notifications`). Android identifies a foreground service's notification purely by its channel + notification ID — any code that posts to that same ID replaces the displayed content. This plugin's own `changeNotificationOptions` already relies on exactly that mechanism internally (a plain `NotificationManagerCompat.notify(notificationId, ...)` call, not a fresh `startForeground()`, to "update" the notification after the service has started).

Since `changeNotificationOptions` already returns the `channelId`/`notificationId` (as `AndroidNotificationData`), an app can call it once to obtain those, then use `flutter_local_notifications` (or any plugin/native code that can call `NotificationManager.notify`) to post fully custom content to that same ID — no new plugin API needed. Documented this technique with a runnable snippet.

Full notification *suppression* (#928's "turn it off entirely") still isn't possible — Android's foreground-service API contractually requires some visible notification — but the channel is already created at the minimum `IMPORTANCE_NONE` level, which is as close as this gets.

## Verification

Docs-only change (`docs/features/notification.mdx`), no code touched.