### PR TITLE
fix(ios): hasPermission() reports deniedForever consistently with requestPermission()

### DIFF
--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -229,6 +229,14 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     private func onHasPermission(result: FlutterResult) {
         if isPermissionGranted {
             result(isHighAccuracyPermitted ? 1 : 3)
+        } else if currentAuthorizationStatus == .denied {
+            // Once authorization has actually been denied, iOS won't show the
+            // system prompt again -- requestPermission() already reflects this
+            // by returning deniedForever for any non-notDetermined, non-granted
+            // status. hasPermission() previously always returned plain `denied`
+            // regardless, inconsistent with what a following requestPermission()
+            // call would report for the same state (#738).
+            result(2)
         } else {
             result(0)
         }


### PR DESCRIPTION
## Summary

**Fixes #738** — `hasPermission()` and `requestPermission()` disagreed about the same authorization state:

```dart
final hasPermission = await location.hasPermission();
// hasPermission == PermissionStatus.denied

final requestPermission = await location.requestPermission();
// requestPermission == PermissionStatus.deniedForever
```

Root cause: `onHasPermission` always returned plain `denied` (`0`) for any non-granted authorization status, while `onRequestPermission` already correctly distinguishes `.notDetermined` (system prompt can still be shown) from anything else already resolved-but-not-granted (returns `deniedForever`/`2`) — because on iOS, once authorization is actually `.denied`, there's no separate "denied but can ask again" state the way Android has; the system won't show the prompt again at all.

So `hasPermission()` reported `denied` for exactly the state `requestPermission()` reports as `deniedForever`. A common flow — check permission, and only call `requestPermission()` if not already permanently denied — would see `denied`, call `requestPermission()` expecting a fresh prompt, and get `deniedForever` back with no prompt ever appearing.

Fix: `hasPermission()` now also returns `deniedForever` when `currentAuthorizationStatus == .denied`, matching `requestPermission()`'s interpretation of that same state.

## Verification

- `flutter build ios --simulator --no-codesign` and `flutter build macos --debug` in `packages/location/example` — both build clean (shared Darwin source).
- Reverted incidental `macos/Runner.xcodeproj` churn from the build so the diff is feature-only.
- Not runtime-reproduced (would need a simulator/device walkthrough denying the permission first); verified by tracing the exact `currentAuthorizationStatus` branches in both methods and confirming they now agree.