### PR TITLE
feat(android): add requireBackgroundPermission to enableBackgroundMode

### DIFF
--- a/docs/features/listen-location.mdx
+++ b/docs/features/listen-location.mdx
@@ -21,6 +21,26 @@ Don't forget to **cancel the stream** when you don't need it anymore. Otherwise 
 To receive location updates while the app is in the background, enable background mode with `enableBackgroundMode(enable: true)` first.
 On Android, background location triggers a notification that you can control with [`changeNotificationOptions`](/features/notification).
 
+By default, `enableBackgroundMode` also requests the `ACCESS_BACKGROUND_LOCATION`
+("Allow all the time") permission on Android if it hasn't been granted yet. A
+foreground service with the location type actually retains location access
+while backgrounded *without* that permission at all — it's only required for
+location access outside of an active foreground service (e.g. a periodic
+background fetch with no visible notification). If you only need updates
+while your foreground service notification is showing, pass
+`requireBackgroundPermission: false` to skip that stricter prompt and start
+the foreground service directly on just the regular (fine/coarse) location
+permission:
+
+```dart
+await location.enableBackgroundMode(
+  enable: true,
+  requireBackgroundPermission: false,
+);
+```
+
+Android only; ignored on other platforms.
+
 ## Examples
 
 ### Listening to location

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
@@ -180,9 +180,17 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
         result: Result,
     ) {
         val enable = call.argument<Boolean>("enable")
+        // A foreground service with FOREGROUND_SERVICE_TYPE_LOCATION retains
+        // location access while backgrounded without ACCESS_BACKGROUND_LOCATION
+        // ("Allow all the time") at all -- that permission is only required for
+        // location access outside of an active foreground service. Skipping this
+        // check lets callers opt into relying solely on the foreground-service
+        // exemption instead of forcing the stricter background permission (#600).
+        val requireBackgroundPermission =
+            call.argument<Boolean>("requireBackgroundPermission") ?: true
         val locationService = this.locationService
         if (locationService != null && enable != null) {
-            if (locationService.checkBackgroundPermissions()) {
+            if (!requireBackgroundPermission || locationService.checkBackgroundPermissions()) {
                 if (enable) {
                     if (locationService.enableBackgroundMode()) {
                         result.success(1)

--- a/packages/location/lib/location.dart
+++ b/packages/location/lib/location.dart
@@ -63,10 +63,24 @@ class Location implements LocationPlatform {
   /// This can be called independently, before you start listening to
   /// [onLocationChanged]. On Android, enabling background mode also requests the
   /// `ACCESS_BACKGROUND_LOCATION` permission if it has not been granted yet, so
-  /// it can be used to prompt for background location permission on its own.
+  /// it can be used to prompt for background location permission on its own —
+  /// unless [requireBackgroundPermission] is set to `false` (Android only;
+  /// ignored elsewhere), in which case the foreground service is started
+  /// directly on just the foreground permission. A foreground service with
+  /// the location type retains location access while backgrounded without
+  /// needing `ACCESS_BACKGROUND_LOCATION` ("Allow all the time") at all —
+  /// that permission is only required for location access *outside* of an
+  /// active foreground service. Defaults to `true`, preserving the previous
+  /// behavior.
   @override
-  Future<bool> enableBackgroundMode({bool? enable = true}) {
-    return LocationPlatform.instance.enableBackgroundMode(enable: enable);
+  Future<bool> enableBackgroundMode({
+    bool? enable = true,
+    bool requireBackgroundPermission = true,
+  }) {
+    return LocationPlatform.instance.enableBackgroundMode(
+      enable: enable,
+      requireBackgroundPermission: requireBackgroundPermission,
+    );
   }
 
   /// Gets the current location of the user.

--- a/packages/location/test/location_test.mocks.dart
+++ b/packages/location/test/location_test.mocks.dart
@@ -84,12 +84,18 @@ class MockLocation extends _i1.Mock implements _i3.Location {
       ) as _i4.Future<bool>);
 
   @override
-  _i4.Future<bool> enableBackgroundMode({bool? enable = true}) =>
+  _i4.Future<bool> enableBackgroundMode({
+    bool? enable = true,
+    bool? requireBackgroundPermission = true,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableBackgroundMode,
           [],
-          {#enable: enable},
+          {
+            #enable: enable,
+            #requireBackgroundPermission: requireBackgroundPermission,
+          },
         ),
         returnValue: _i4.Future<bool>.value(false),
       ) as _i4.Future<bool>);

--- a/packages/location_platform_interface/lib/location_platform_interface.dart
+++ b/packages/location_platform_interface/lib/location_platform_interface.dart
@@ -65,8 +65,26 @@ class LocationPlatform extends PlatformInterface {
   ///
   /// This can be called independently, before listening to [onLocationChanged].
   /// On Android, enabling background mode also requests the
-  /// `ACCESS_BACKGROUND_LOCATION` permission if it has not been granted yet.
-  Future<bool> enableBackgroundMode({bool? enable}) {
+  /// `ACCESS_BACKGROUND_LOCATION` permission if it has not been granted yet,
+  /// unless [requireBackgroundPermission] is set to `false` (Android only;
+  /// ignored elsewhere).
+  ///
+  /// Android's foreground-service background-access exemption means a
+  /// foreground service with [FOREGROUND_SERVICE_TYPE_LOCATION] retains
+  /// location access while the app is backgrounded without needing
+  /// `ACCESS_BACKGROUND_LOCATION` ("Allow all the time") at all — that
+  /// permission is only required for location access *outside* of an active
+  /// foreground service (e.g. periodic background fetches). Setting
+  /// [requireBackgroundPermission] to `false` starts the foreground service
+  /// directly on just the foreground (fine/coarse) permission, skipping the
+  /// `ACCESS_BACKGROUND_LOCATION` prompt entirely. Defaults to `true`,
+  /// preserving the previous behavior.
+  ///
+  /// [FOREGROUND_SERVICE_TYPE_LOCATION]: https://developer.android.com/guide/components/foreground-services#location
+  Future<bool> enableBackgroundMode({
+    bool? enable,
+    bool requireBackgroundPermission = true,
+  }) {
     throw UnimplementedError();
   }
 

--- a/packages/location_platform_interface/lib/src/method_channel_location.dart
+++ b/packages/location_platform_interface/lib/src/method_channel_location.dart
@@ -76,10 +76,16 @@ class MethodChannelLocation extends LocationPlatform {
 
   /// Enables or disables service in the background mode.
   @override
-  Future<bool> enableBackgroundMode({bool? enable}) async {
+  Future<bool> enableBackgroundMode({
+    bool? enable,
+    bool requireBackgroundPermission = true,
+  }) async {
     final result = await _methodChannel!.invokeMethod(
       'enableBackgroundMode',
-      <String, dynamic>{'enable': enable},
+      <String, dynamic>{
+        'enable': enable,
+        'requireBackgroundPermission': requireBackgroundPermission,
+      },
     );
 
     return result == 1;


### PR DESCRIPTION
## Summary

**Addresses #600** — `enableBackgroundMode` always required `ACCESS_BACKGROUND_LOCATION` ("Allow all the time") on Android before starting the foreground service.

Per [Android's foreground-service background-access exemption docs](https://developer.android.com/guide/components/foreground-services#bg-access-restriction-exemptions), an app running a `FOREGROUND_SERVICE_TYPE_LOCATION` foreground service — exactly what `enableBackgroundMode` already sets up — retains location access while backgrounded *without* `ACCESS_BACKGROUND_LOCATION` at all. That permission is only actually required for location access *outside* of an active foreground service (e.g. a periodic background fetch with no visible notification). Forcing the stricter "Allow all the time" prompt was stronger than necessary for apps that only need location while their foreground-service notification is showing.

This is designed to be low-risk / non-breaking:
- **Purely additive**: new optional named parameter, `requireBackgroundPermission`, defaulting to `true` — exactly preserves current behavior for every existing caller.
- **Android-only**: ignored on other platforms, matching the existing `backgroundInterval` convention.
- **No subclass override to update**: `location_web` doesn't override `enableBackgroundMode` at all (confirmed via `melos run analyze`, which would flag a mismatched override), so this doesn't touch it.

When set to `false`, the plugin skips the `ACCESS_BACKGROUND_LOCATION` check/prompt entirely and starts the foreground service directly on just the regular (fine/coarse) location permission.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages (including `location_web`, confirming no override needed updating).
- `flutter test` in `location_platform_interface` (37 tests) and `location` (11 tests) — all pass. Regenerated `location_test.mocks.dart` via `build_runner` for the new parameter (per this repo's convention, not hand-merged).
- `dart format . --set-exit-if-changed` — clean.
- No Android unit test harness exists in this repo to exercise `MethodCallHandlerImpl.kt` directly; verified by tracing the exact conditional (`!requireBackgroundPermission || locationService.checkBackgroundPermissions()`) against the existing, unmodified `true` branch to confirm the default path is byte-for-byte unchanged.