### PR TITLE
feat(android): accept raw bytes for the notification icon/image

### DIFF
--- a/docs/features/notification.mdx
+++ b/docs/features/notification.mdx
@@ -13,6 +13,8 @@ Future<bool> changeNotificationOptions({
   String? title,
   String? iconName,
   String? imageName,
+  Uint8List? iconBytes,
+  Uint8List? imageBytes,
   String? subtitle,
   String? description,
   Color? color,
@@ -43,6 +45,45 @@ shrinker to keep it by adding a `res/raw/keep.xml` to your Android app:
 See Android's [shrink, obfuscate, and optimize your
 app](https://developer.android.com/build/shrink-code#keep-resources) guide for
 details.
+
+### Setting an icon without a drawable resource
+
+`iconBytes`/`imageBytes` are an alternative to `iconName`/`imageName` for apps
+that don't want to manually add a drawable resource to their Android project
+— e.g. to use one of Flutter's own `Icons` instead. Render it to PNG bytes at
+runtime and pass the bytes directly; when both a name and bytes are provided
+for the same icon, the bytes take precedence.
+
+```dart
+Future<Uint8List> iconDataToPngBytes(IconData icon, {double size = 24, Color color = Colors.white}) async {
+  final recorder = PictureRecorder();
+  final canvas = Canvas(recorder);
+  final painter = TextPainter(textDirection: TextDirection.ltr)
+    ..text = TextSpan(
+      text: String.fromCharCode(icon.codePoint),
+      style: TextStyle(
+        fontSize: size,
+        fontFamily: icon.fontFamily,
+        package: icon.fontPackage,
+        color: color,
+      ),
+    )
+    ..layout();
+  painter.paint(canvas, Offset.zero);
+  final image = await recorder.endRecording().toImage(size.ceil(), size.ceil());
+  final bytes = await image.toByteData(format: ImageByteFormat.png);
+  return bytes!.buffer.asUint8List();
+}
+
+await location.changeNotificationOptions(
+  iconBytes: await iconDataToPngBytes(Icons.location_on),
+);
+```
+
+Android's small-icon convention expects a white silhouette on a transparent
+background (the system tints it to match the status bar) — render your icon
+accordingly for it to look right; this plugin decodes whatever bytes it's
+given as-is.
 
 ## Examples
 

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocationService.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocationService.kt
@@ -21,6 +21,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
+import androidx.core.graphics.drawable.IconCompat
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.PluginRegistry
 
@@ -33,6 +34,8 @@ data class NotificationOptions(
     val title: String = DEFAULT_NOTIFICATION_TITLE,
     val iconName: String = DEFAULT_NOTIFICATION_ICON_NAME,
     val imageName: String? = null,
+    val iconBytes: ByteArray? = null,
+    val imageBytes: ByteArray? = null,
     val subtitle: String? = null,
     val description: String? = null,
     val color: Int? = null,
@@ -90,24 +93,35 @@ class BackgroundNotification(
         options: NotificationOptions,
         notify: Boolean,
     ) {
-        val iconId =
-            getDrawableId(options.iconName).let {
-                if (it != 0) it else getDrawableId(DEFAULT_NOTIFICATION_ICON_NAME)
-            }
+        // iconBytes/imageBytes let a caller supply a pre-rendered icon (e.g. a
+        // Flutter IconData rasterized to PNG bytes) instead of adding a drawable
+        // resource to their Android project by name (#1017). Bytes take
+        // precedence over the by-name lookup when both are provided.
         val largeIcon =
-            options.imageName?.let { imageName ->
-                getDrawableId(imageName).let { imageId ->
-                    if (imageId != 0) {
-                        BitmapFactory.decodeResource(context.resources, imageId)
-                    } else {
-                        null
+            options.imageBytes?.let { bytes -> BitmapFactory.decodeByteArray(bytes, 0, bytes.size) }
+                ?: options.imageName?.let { imageName ->
+                    getDrawableId(imageName).let { imageId ->
+                        if (imageId != 0) {
+                            BitmapFactory.decodeResource(context.resources, imageId)
+                        } else {
+                            null
+                        }
                     }
                 }
+        builder =
+            if (options.iconBytes != null) {
+                val bitmap = BitmapFactory.decodeByteArray(options.iconBytes, 0, options.iconBytes.size)
+                builder.setSmallIcon(IconCompat.createWithBitmap(bitmap))
+            } else {
+                val iconId =
+                    getDrawableId(options.iconName).let {
+                        if (it != 0) it else getDrawableId(DEFAULT_NOTIFICATION_ICON_NAME)
+                    }
+                builder.setSmallIcon(iconId)
             }
         builder =
             builder
                 .setContentTitle(options.title)
-                .setSmallIcon(iconId)
                 .setLargeIcon(largeIcon)
                 .setContentText(options.subtitle)
                 .setSubText(options.description)

--- a/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
@@ -216,6 +216,8 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
             val title = call.argument<String>("title") ?: DEFAULT_NOTIFICATION_TITLE
             val iconName = call.argument<String>("iconName") ?: DEFAULT_NOTIFICATION_ICON_NAME
             val imageName = call.argument<String>("imageName")
+            val iconBytes = call.argument<ByteArray>("iconBytes")
+            val imageBytes = call.argument<ByteArray>("imageBytes")
             val subtitle = call.argument<String>("subtitle")
             val description = call.argument<String>("description")
             val onTapBringToFront = call.argument<Boolean>("onTapBringToFront") ?: false
@@ -229,6 +231,8 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
                     title,
                     iconName,
                     imageName,
+                    iconBytes,
+                    imageBytes,
                     subtitle,
                     description,
                     color,

--- a/packages/location/lib/location.dart
+++ b/packages/location/lib/location.dart
@@ -1,5 +1,6 @@
 // Ignored since there is a bug in the coverage report tool
 // https://github.com/dart-lang/coverage/issues/339 coverage:ignore-file
+import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:location_platform_interface/location_platform_interface.dart';
@@ -163,6 +164,13 @@ class Location implements LocationPlatform {
   /// resolved to a drawable resource in the same way as [iconName]. If no
   /// matching resource is found, no large icon is shown.
   ///
+  /// [iconBytes]/[imageBytes] are an alternative to [iconName]/[imageName]
+  /// for apps that don't want to manually add a drawable resource to their
+  /// Android project (e.g. to render a Flutter icon to PNG bytes at runtime
+  /// instead) — decoded directly into the small/large icon bitmap. When both
+  /// are provided for the same icon, the bytes take precedence over the
+  /// resource name.
+  ///
   /// When [onTapBringToFront] is set to true, tapping the notification will
   /// bring the activity back to the front.
   ///
@@ -181,6 +189,8 @@ class Location implements LocationPlatform {
     String? title,
     String? iconName,
     String? imageName,
+    Uint8List? iconBytes,
+    Uint8List? imageBytes,
     String? subtitle,
     String? description,
     Color? color,
@@ -191,6 +201,8 @@ class Location implements LocationPlatform {
       title: title,
       iconName: iconName,
       imageName: imageName,
+      iconBytes: iconBytes,
+      imageBytes: imageBytes,
       subtitle: subtitle,
       description: description,
       color: color,

--- a/packages/location/test/location_test.mocks.dart
+++ b/packages/location/test/location_test.mocks.dart
@@ -4,7 +4,8 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i4;
-import 'dart:ui' as _i5;
+import 'dart:typed_data' as _i5;
+import 'dart:ui' as _i6;
 
 import 'package:location/location.dart' as _i3;
 import 'package:location_platform_interface/location_platform_interface.dart'
@@ -171,9 +172,11 @@ class MockLocation extends _i1.Mock implements _i3.Location {
     String? title,
     String? iconName,
     String? imageName,
+    _i5.Uint8List? iconBytes,
+    _i5.Uint8List? imageBytes,
     String? subtitle,
     String? description,
-    _i5.Color? color,
+    _i6.Color? color,
     bool? onTapBringToFront,
   }) =>
       (super.noSuchMethod(
@@ -185,6 +188,8 @@ class MockLocation extends _i1.Mock implements _i3.Location {
             #title: title,
             #iconName: iconName,
             #imageName: imageName,
+            #iconBytes: iconBytes,
+            #imageBytes: imageBytes,
             #subtitle: subtitle,
             #description: description,
             #color: color,

--- a/packages/location_platform_interface/lib/location_platform_interface.dart
+++ b/packages/location_platform_interface/lib/location_platform_interface.dart
@@ -159,6 +159,13 @@ class LocationPlatform extends PlatformInterface {
   /// resolved to a drawable resource in the same way as [iconName]. If no
   /// matching resource is found, no large icon is shown.
   ///
+  /// [iconBytes]/[imageBytes] are an alternative to [iconName]/[imageName]
+  /// for apps that don't want to manually add a drawable resource to their
+  /// Android project (e.g. to render a Flutter icon to PNG bytes at runtime
+  /// instead) — decoded directly into the small/large icon bitmap. When both
+  /// are provided for the same icon, the bytes take precedence over the
+  /// resource name.
+  ///
   /// When [onTapBringToFront] is set to true, tapping the notification will
   /// bring the activity back to the front.
   ///
@@ -176,6 +183,8 @@ class LocationPlatform extends PlatformInterface {
     String? title,
     String? iconName,
     String? imageName,
+    Uint8List? iconBytes,
+    Uint8List? imageBytes,
     String? subtitle,
     String? description,
     Color? color,

--- a/packages/location_platform_interface/lib/src/method_channel_location.dart
+++ b/packages/location_platform_interface/lib/src/method_channel_location.dart
@@ -216,6 +216,8 @@ class MethodChannelLocation extends LocationPlatform {
     String? title,
     String? iconName,
     String? imageName,
+    Uint8List? iconBytes,
+    Uint8List? imageBytes,
     String? subtitle,
     String? description,
     Color? color,
@@ -235,6 +237,14 @@ class MethodChannelLocation extends LocationPlatform {
 
     if (imageName != null) {
       data['imageName'] = imageName;
+    }
+
+    if (iconBytes != null) {
+      data['iconBytes'] = iconBytes;
+    }
+
+    if (imageBytes != null) {
+      data['imageBytes'] = imageBytes;
     }
 
     if (subtitle != null) {

--- a/packages/location_web/lib/location_web.dart
+++ b/packages/location_web/lib/location_web.dart
@@ -184,6 +184,8 @@ class LocationWebPlugin extends LocationPlatform {
     String? title,
     String? iconName,
     String? imageName,
+    Uint8List? iconBytes,
+    Uint8List? imageBytes,
     String? subtitle,
     String? description,
     Color? color,


### PR DESCRIPTION
## Summary

**Addresses #1017** — the request was specifically for `IconData` support in `iconName`, but Android's notification icon needs an actual bitmap/drawable; there's no way to hand a Flutter `IconData` (a font glyph reference) to native code directly. Rather than have the plugin itself render `IconData` (which would need visual verification of font-glyph rasterization that I can't do without running the app on a device and looking at the resulting notification), I added a smaller, purely additive building block: `iconBytes`/`imageBytes`, accepting raw PNG bytes that the caller renders however they like — including a documented `IconData`-to-bytes snippet using `TextPainter`/`PictureRecorder` for exactly the `Icons.*` use case the issue asked for, but the plugin itself doesn't have to guess at rendering correctness.

- `imageBytes` (large icon): decoded via `BitmapFactory.decodeByteArray` into a `Bitmap`, same as the existing by-name path.
- `iconBytes` (small icon): decoded the same way, then wrapped via `IconCompat.createWithBitmap(bitmap)` and passed to `NotificationCompat.Builder.setSmallIcon(IconCompat)` — verified this overload actually exists in the resolved AndroidX version by building the example app, since I wasn't fully certain the compat API had it.
- When both a name and bytes are given for the same icon, bytes take precedence.
- Purely additive: existing `iconName`/`imageName`-only callers are completely unaffected.

Per the "new `LocationPlatform` parameter breaks every override" pattern noted elsewhere in this repo's history, `location_web`'s explicit `changeNotificationOptions` override (which lists every named parameter) needed the same two new parameters added (still no-ops there, Android only) to keep compiling.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean; this is also how I confirmed `setSmallIcon(IconCompat)` actually exists in this project's resolved AndroidX Core version, since I wasn't certain going in.
- `melos run analyze` — 0 issues across all packages, including `location_web` (confirms its override was updated correctly).
- `flutter test` in `location_platform_interface` (37 tests) and `location` (11 tests) — all pass. Regenerated `location_test.mocks.dart` via `build_runner` for the new parameters (not hand-merged).
- `dart format . --set-exit-if-changed` — clean.
- Not visually verified on a device/emulator (no way to see the resulting notification icon in this sandbox) — the byte-decoding path is exercised by the build succeeding, but whether a *specific* rendered icon looks correct in the status bar is the caller's responsibility, same as it would be if they'd manually created an incorrect drawable resource. Documented Android's small-icon silhouette convention so callers know what to render.