### PR TITLE
ci: add a workflow to build and deploy the web demo to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-web-demo.yaml
+++ b/.github/workflows/deploy-web-demo.yaml
@@ -1,0 +1,63 @@
+name: Deploy web demo
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "packages/location/example/**"
+      - "packages/location/lib/**"
+      - "packages/location_platform_interface/**"
+      - "packages/location_web/**"
+      - ".github/workflows/deploy-web-demo.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Set up Melos
+        run: dart pub global activate melos
+
+      - name: melos bootstrap
+        run: melos bootstrap
+
+      - name: Build web demo
+        working-directory: packages/location/example
+        run: flutter build web --base-href /flutterlocation/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/location/example/build/web
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/location/example/web/index.html
+++ b/packages/location/example/web/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <base href="$FLUTTER_BASE_HREF">
+
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Demonstrates how to use the location plugin.">


### PR DESCRIPTION
## Summary

**Addresses #966** — the README links to a "Web demo" at `lyokone.github.io/flutterlocation`, but the repo's GitHub Pages source is currently configured as "Deploy from a branch: `master`, path `/docs`" — that's the docs *source* mdx files, not a built site (the actual docs site is hosted separately via docs.page, per `pubspec.yaml`'s `homepage` field). Nothing in this repo actually builds or deploys a Flutter web demo, so the link has been broken.

Added `.github/workflows/deploy-web-demo.yaml`: builds `packages/location/example` for web on every push to `master` (also manually via `workflow_dispatch`) and deploys it using GitHub's official Pages Actions (`upload-pages-artifact` + `deploy-pages`) — the modern, GitHub-recommended approach, no extra `gh-pages` branch needed.

Also added the missing `<base href="$FLUTTER_BASE_HREF">` placeholder to `packages/location/example/web/index.html`. This is required for `flutter build web --base-href` to work at all when deploying to a subpath (`/flutterlocation/`, not the domain root) — I confirmed the build fails with a clear error without it, and succeeds with it.

**⚠️ This can't fully close #966 by itself.** GitHub Pages' *source* setting needs to be switched from "Deploy from a branch" to "GitHub Actions" in the repo's own Settings → Pages UI — that requires repo admin access I don't have. Once you flip that one setting, this workflow handles building and deploying the demo automatically on every push to `master`.

## Verification

- `flutter build web --base-href /flutterlocation/` in `packages/location/example` — builds clean, confirmed by running it locally (both the failure without the `<base>` tag, and the success with it).
- Validated the workflow YAML syntax.
- Reverted incidental `.gitignore` churn from the build so the diff is feature-only.
- Could not test the actual deployment (requires the Pages source setting change + a real push to `master` to trigger the workflow), so the `deploy` job's exact behavior is unverified beyond following GitHub's documented `actions/deploy-pages` pattern precisely.