### PR TITLE
fix(android): surface the real exception from serviceEnabled()'s SERVICE_STATUS_ERROR

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/MethodCallHandlerImpl.kt
@@ -149,7 +149,14 @@ internal class MethodCallHandlerImpl : MethodCallHandler {
         try {
             result.success(if (location.checkServiceEnabled()) 1 else 0)
         } catch (e: Exception) {
-            result.error("SERVICE_STATUS_ERROR", "Location service status couldn't be determined", null)
+            // Surface the real exception instead of a fixed, uninformative message
+            // (#1020) -- this was previously discarded, making the actual failure
+            // impossible to diagnose from a bug report alone.
+            result.error(
+                "SERVICE_STATUS_ERROR",
+                "Location service status couldn't be determined: ${e.message}",
+                e.stackTraceToString(),
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

**Diagnostic improvement for #1020** (not claiming `Fixes` — this doesn't identify #1020's specific root cause, since the original exception was never captured anywhere; it makes sure the *next* occurrence, and any future report like it, actually includes enough information to diagnose).

`onServiceEnabled` caught any `Exception` from `checkServiceEnabled()` and always reported the same fixed message — `"Location service status couldn't be determined"` — discarding the actual exception entirely. This is why #1020 (and similar past reports) could never be root-caused: the real failure was thrown away before it ever reached a bug report.

`onChangeSettings` and `onChangeNotificationOptions` already include `e.message` in their error messages; this brings `onServiceEnabled` in line with that existing pattern, and also passes the stack trace as the error's `details` for good measure.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages.
- No Android unit test harness exists in this repo to exercise this directly; verified by comparing against the two sibling `catch` blocks in the same file that already follow this pattern.