### PR TITLE
docs: bump README version reference and label the manifest file path

### DIFF
--- a/docs/installation/android.mdx
+++ b/docs/installation/android.mdx
@@ -37,7 +37,7 @@ theme of your app to `Theme.AppCompat.Light.NoActionBar`:
 In order to receive background location, you need to add the following
 permissions to your manifest:
 
-```xml
+```xml name="android/app/src/main/AndroidManifest.xml"
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/packages/location/README.md
+++ b/packages/location/README.md
@@ -31,7 +31,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  location: ^8.0.0
+  location: ^9.0.0
 ```
 
 ### Android


### PR DESCRIPTION
## Summary

Two small doc fixes found while auditing old community PRs for staleness:

- `packages/location/README.md` install snippet pointed at `location: ^8.0.0`. The
  latest released version is `9.0.0` (see CHANGELOG.md — there's already an
  `## 9.0.0` section above `## Unreleased`), so bump the shown constraint.
- `docs/installation/android.mdx`'s background-location manifest snippet had no file
  path label, unlike the `styles.xml` snippet directly above it in the same doc.
  Added the same `name="..."` convention for consistency.

Related to (supersedes, with corrected/consistent content):
- #1039 "Update location package version in README" — that PR bumps to `^8.0.1`,
  which is now also stale since `9.0.0` shipped.
- #1045 "Improve Android permission setup instruction" — that PR adds a raw text
  line ("configuration path - ...") instead of using the existing code-fence
  `name="..."` convention already used elsewhere in the same file.

Not asserting `Fixes` on either since they're PRs, not issues — leaving the call of
whether to close them to the maintainer.

## Verification

- Visual diff review only (doc-only change, no code).