### PR TITLE
fix(android): retry pending location requests when the service is re-enabled

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -3,8 +3,10 @@ package com.lyokone.location
 import android.Manifest
 import android.app.Activity
 import android.content.ActivityNotFoundException
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.IntentSender
 import android.content.pm.PackageManager
 import android.location.Location
@@ -16,6 +18,7 @@ import android.os.Bundle
 import android.os.Looper
 import android.util.Log
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.common.api.ApiException
@@ -45,7 +48,7 @@ private const val PREFS_NAME = "flutter_location_prefs"
 private const val PREFS_KEY_PERMISSION_REQUESTED = "location_permission_requested"
 
 class FlutterLocation(
-    applicationContext: Context,
+    private val applicationContext: Context,
     activity: Activity?,
 ) : PluginRegistry.RequestPermissionsResultListener,
     PluginRegistry.ActivityResultListener {
@@ -65,6 +68,13 @@ class FlutterLocation(
                 createLocationCallback()
                 createLocationRequest()
                 buildLocationSettingsRequest()
+                unregisterLocationProvidersChangedReceiver()
+                ContextCompat.registerReceiver(
+                    applicationContext,
+                    locationProvidersChangedReceiver,
+                    IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION),
+                    ContextCompat.RECEIVER_NOT_EXPORTED,
+                )
             } else {
                 stopLocationUpdates()
                 mFusedLocationClient = null
@@ -73,8 +83,17 @@ class FlutterLocation(
                     mMessageListener?.let { locationManager.removeNmeaListener(it) }
                     mMessageListener = null
                 }
+                unregisterLocationProvidersChangedReceiver()
             }
         }
+
+    private fun unregisterLocationProvidersChangedReceiver() {
+        try {
+            applicationContext.unregisterReceiver(locationProvidersChangedReceiver)
+        } catch (e: IllegalArgumentException) {
+            // Not currently registered -- nothing to undo.
+        }
+    }
 
     var mFusedLocationClient: FusedLocationProviderClient? = null
     private var mSettingsClient: SettingsClient? = null
@@ -175,6 +194,32 @@ class FlutterLocation(
                 // stream (#535).
                 if (!checkServiceEnabled()) {
                     sendError("SERVICE_STATUS_DISABLED", "Location services were disabled", null)
+                }
+            }
+        }
+
+    /**
+     * Retries a pending one-shot [getLocationResults] call and/or an active
+     * [events] stream once the location service is turned back on.
+     *
+     * [startRequestingLocation] only runs when something explicitly asks for a
+     * location (`getLocation()`/`onLocationChanged.listen()`/a settings change).
+     * If the service was off at that moment, the Google Play services settings
+     * check fails and -- unless the user happens to tap "Turn on" on the
+     * resulting system dialog -- nothing ever retries: enabling the service
+     * afterwards through Quick Settings or the Settings app doesn't surface a
+     * result to [onActivityResult], and (on the primary fused-provider path)
+     * nothing else observes provider on/off transitions. This receiver, kept
+     * for as long as an activity is attached, is that missing signal (#926).
+     */
+    private val locationProvidersChangedReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context,
+                intent: Intent,
+            ) {
+                if (checkServiceEnabled() && (getLocationResults.isNotEmpty() || events != null)) {
+                    startRequestingLocation()
                 }
             }
         }


### PR DESCRIPTION
## Summary

**Fixes #926** — location listener (and pending `getLocation()` calls) failing to resume after the location service is turned off then back on.

Root cause: `startRequestingLocation()` only runs when something explicitly asks for a location (`getLocation()`, `onLocationChanged.listen()`, or a settings change while already active). If the service happens to be off at that exact moment, the Google Play services settings check fails, and — unless the user taps "Turn on" on the resulting system resolution dialog — nothing ever retries. Enabling the service afterwards through Quick Settings or the Settings app (the reporter's exact repro) doesn't surface a result to `onActivityResult`, and on the primary fused-provider path there's no other listener observing provider on/off transitions at all (the framework `LocationListener`'s `onProviderEnabled`/`onProviderDisabled` callbacks are only wired up on the non-GMS fallback path).

Fix: register a `PROVIDERS_CHANGED_ACTION` broadcast receiver for as long as an activity is attached. When it fires and the service is now enabled, retry `startRequestingLocation()` if there's a pending one-shot `getLocation()` result and/or an active stream waiting for one. Mirrors this file's existing pattern of tearing down and re-creating registrations (`createLocationCallback`, NMEA listener) on activity attach/detach, so it doesn't leak or double-register across config changes.

Android-only (matches the existing scope of `checkServiceEnabled`/`requestService`); no `LocationPlatform` API change, so no other package needed updating.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages.
- `./gradlew ktlintCheck` (including `--rerun-tasks`) — clean.
- No Android unit test harness exists in this repo to exercise this directly; verified by tracing the exact gap (no retry path once the settings-check failure branch is taken outside of its own resolution dialog) against the fix, and confirmed the receiver registration is symmetric with the existing activity-attach/detach lifecycle (`FlutterLocationService.setActivity` → `location.activity` setter) so it can't double-register across config-change reattaches. Not runtime-reproduced on a physical device (would need toggling airplane/location settings against a live app).