### PR TITLE
fix(android): catch SecurityException from the fused provider's requestLocationUpdates

### DIFF
--- a/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
+++ b/packages/location/android/src/main/kotlin/com/lyokone/location/FlutterLocation.kt
@@ -783,7 +783,16 @@ class FlutterLocation(
     private fun requestLocationUpdates() {
         val request = mLocationRequest ?: return
         val callback = mLocationCallback ?: return
-        mFusedLocationClient?.requestLocationUpdates(request, callback, Looper.myLooper())
+        try {
+            mFusedLocationClient?.requestLocationUpdates(request, callback, Looper.myLooper())
+        } catch (e: SecurityException) {
+            // The permission check in checkPermissions()/startRequestingLocation()
+            // and this call are not atomic -- a permission granted only "for this
+            // time" (Android 11+) can be revoked by the OS in between, e.g. after
+            // the app has been backgrounded for a while (#767). Surface it as a
+            // normal error instead of letting it crash the app.
+            sendError("PERMISSION_DENIED", e.message ?: "Location permission denied", null)
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

**Possibly fixes #767** (not claiming a certain `Fixes` since no stack trace was ever captured on the issue to confirm this was the actual crash — but it's a real, verifiable gap that matches the reported symptom closely) — app freezing/crashing when the location permission expires (Android 11+ "Only this time" grant) while a location request is active.

Found while investigating #767: the permission check (`checkPermissions()`) and the actual `FusedLocationProviderClient.requestLocationUpdates()` call in `requestLocationUpdates()` are not atomic. An "Only this time" grant can be revoked by the OS in the gap between them — e.g. the app is backgrounded for a while during an active `onLocationChanged` stream, the ephemeral grant expires, then the app resumes and the plugin re-registers for updates using the now-stale permission state. `requestLocationUpdates()` throws `SecurityException` in that case, and this file's fused-provider call site was the only one of its request-call sites that didn't already guard against it — its own framework-fallback sibling (`requestLocationUpdatesFramework`) and `getLastKnownLocation`/`getLastKnownLocationFramework` all already catch `SecurityException` and surface it as a normal `PERMISSION_DENIED` error instead.

Fix: wrap the fused-provider call the same way, calling the existing `sendError` path instead of letting the exception propagate uncaught.

## Verification

- `flutter build apk --debug` in `packages/location/example` — builds clean.
- `melos run analyze` — 0 issues across all packages.
- `./gradlew ktlintCheck --rerun-tasks` — clean.
- No Android unit test harness exists in this repo to trigger a real permission revocation mid-request; verified by comparing this call site against the three sibling call sites in the same file that already catch `SecurityException` the same way, confirming this was the one inconsistent spot. Not runtime-reproduced on a physical device.