### PR TITLE
fix(android): guard kotlin-android apply for AGP 9's built-in Kotlin support

### DIFF
--- a/packages/location/android/build.gradle
+++ b/packages/location/android/build.gradle
@@ -21,7 +21,12 @@ repositories {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "org.jetbrains.kotlin.android"
+
+def agpMajor = Integer.parseInt(com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.split("\\.")[0])
+if (agpMajor < 9) {
+    apply plugin: "org.jetbrains.kotlin.android"
+}
+
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {


### PR DESCRIPTION
## Summary

**Fixes #1048** — AGP 9+ deprecated the standalone Kotlin Gradle Plugin (KGP) in favor of AGP's own built-in Kotlin support (`android.builtInKotlin=true` by default on AGP 9+). This plugin applied `kotlin-android` unconditionally, which will break once Flutter removes its temporary `android.builtInKotlin=false` compatibility shim ([flutter/flutter#181383](https://github.com/flutter/flutter/issues/181383)).

Guards the apply the same way `device_info_plus`, `package_info_plus` and `share_plus` already do in production:

```groovy
def agpMajor = Integer.parseInt(com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.split("\\.")[0])
if (agpMajor < 9) {
    apply plugin: "org.jetbrains.kotlin.android"
}
```

### Note on the earlier "this is riskier than it looks" comment on the issue

I'd previously investigated this and posted a comment concluding the guard was unsafe — that merely referencing `com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION` caused Flutter's tooling to disable its own AGP-9 shim for the whole project, exposing that the example app's own template `build.gradle` wasn't "new DSL"-compatible. Re-investigated properly this time, isolating each step: that conclusion was wrong. The actual failure was Groovy's `.toInt()` extension method not resolving in this build script's evaluation context (`No signature of method: java.lang.String.toInt()` — a `MissingMethodException` unrelated to AGP/Flutter at all). The "Starting AGP 9+, only the new DSL interface will be read" hint that appeared alongside it is Flutter's post-*build-failure* diagnostic advice box, which fires based on static detection of the `com.android.Version` reference in the tree regardless of cause — it doesn't reflect an actual shim being disabled. Swapping to `Integer.parseInt()` (a plain Java static call, not a Groovy DGM extension) avoids the crash entirely, and a full clean rebuild then succeeds with no warnings at all, matching how the three reference plugins already ship this in production. Posting a correction on the issue itself as well.

## Verification

- `flutter clean` + `flutter build apk --debug` in `packages/location/example` — clean rebuild from scratch, succeeds with no warnings (verified the earlier failure mode is gone, not just papered over).
- `melos run analyze` — 0 issues across all packages.
- `./gradlew ktlintCheck --rerun-tasks` — clean (ktlint doesn't lint Groovy `build.gradle`, but confirms nothing else regressed).
- Compared against `device_info_plus`'s current production `build.gradle.kts` (fetched from `fluttercommunity/plus_plugins`) to confirm the pattern itself is sound and already battle-tested at scale.
- Can't test the actual AGP 9+ branch (no AGP 9 artifact is publicly available yet to pull into this environment), but the `agpMajor < 9` branch (today's real case, AGP 8.11.1) is now proven not to regress, and the guard logic itself is identical to the already-shipping reference implementations.