### PR TITLE
fix(ios,macos): fix two permission edge cases that hang getLocation()

### DIFF
--- a/packages/location/darwin/location/Sources/location/LocationPlugin.swift
+++ b/packages/location/darwin/location/Sources/location/LocationPlugin.swift
@@ -195,7 +195,11 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
                 ))
                 return
             }
-            if self.currentAuthorizationStatus == .denied {
+            // .restricted (parental controls / MDM) needs the same early-out as
+            // .denied: requestPermission() below is a no-op for it (CLLocationManager
+            // cannot prompt for or change a restricted status), so without this the
+            // pending result appended just below would never resolve.
+            if self.isPermissionDeniedOrRestricted {
                 result(FlutterError(
                     code: "PERMISSION_DENIED",
                     message: "The user explicitly denied the use of location services for this app or "
@@ -229,17 +233,26 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
     private func onHasPermission(result: FlutterResult) {
         if isPermissionGranted {
             result(isHighAccuracyPermitted ? 1 : 3)
-        } else if currentAuthorizationStatus == .denied {
-            // Once authorization has actually been denied, iOS won't show the
-            // system prompt again -- requestPermission() already reflects this
-            // by returning deniedForever for any non-notDetermined, non-granted
-            // status. hasPermission() previously always returned plain `denied`
-            // regardless, inconsistent with what a following requestPermission()
-            // call would report for the same state (#738).
+        } else if isPermissionDeniedOrRestricted {
+            // Once authorization has actually been denied (or is restricted by
+            // parental controls/MDM), iOS won't show the system prompt again --
+            // requestPermission() already reflects this by returning deniedForever
+            // for any non-notDetermined, non-granted status. hasPermission()
+            // previously always returned plain `denied` regardless, inconsistent
+            // with what a following requestPermission() call would report for the
+            // same state (#738).
             result(2)
         } else {
             result(0)
         }
+    }
+
+    /// Whether the current authorization status can never turn into a grant
+    /// without the user leaving the app to change it in Settings: either an
+    /// explicit `.denied`, or `.restricted` (parental controls/MDM), for which
+    /// `CLLocationManager` cannot prompt or change the status at all.
+    private var isPermissionDeniedOrRestricted: Bool {
+        currentAuthorizationStatus == .denied || currentAuthorizationStatus == .restricted
     }
 
     /// Whether background ("Always") location authorization has been granted.
@@ -481,12 +494,20 @@ public class LocationPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLo
                 permissionWanted = false
                 flutterResult?(0)
                 flutterResult = nil
-            } else if !pendingLocationResults.isEmpty {
+            }
+            if !pendingLocationResults.isEmpty {
                 // getLocation() requested permission just-in-time (status was
                 // .notDetermined) and the user denied it. Without this, the pending
                 // result(s) were never resolved and the Dart Future(s) from
                 // getLocation() hung forever instead of throwing, since only the
                 // requestPermission() flow above resolved on denial (#979).
+                //
+                // This must be a second independent `if`, not `else if`: a
+                // concurrent requestPermission() + getLocation() pair (the same
+                // shape of concurrent call the #977 fix targets) can leave both
+                // permissionWanted and pendingLocationResults non-empty at once,
+                // and an `else if` here silently dropped the getLocation() side,
+                // leaving those Futures hanging forever.
                 let error = FlutterError(
                     code: "PERMISSION_DENIED",
                     message: "The user explicitly denied the use of location services for this app or "


### PR DESCRIPTION
## Summary

Found while independently reviewing the Swift changes merged this session (dispatched a separate review pass to check for cross-PR interaction mistakes). Two real, verified hangs in `LocationPlugin.swift`:

**1. `else if` in the denial path silently drops concurrent `getLocation()` calls (regression from #977's rewrite of #979's fix).**

`handleAuthorizationChange`'s `.denied` branch was:
```swift
if permissionWanted {
    ...
} else if !pendingLocationResults.isEmpty {
    ...
}
```
`permissionWanted` (set by `requestPermission()`) and `pendingLocationResults` (populated by `getLocation()`) are independent state — a concurrent `requestPermission()` + `getLocation()` pair (the exact shape of concurrent call #977 was written to handle) can leave both true/non-empty at once. With `else if`, only the `permissionWanted` branch ran on denial; the queued `getLocation()` futures were never errored and hung forever. The granted path a few lines below already uses two independent `if`s for the same two pieces of state — the denied path needed the same shape. Now both run independently.

**2. `.restricted` (parental controls/MDM) wasn't handled the same as `.denied`.**

`onGetLocation` only early-out-errored on `.denied`; for `.restricted` it queued a pending result and called the private `requestPermission()`, which calls `CLLocationManager.requestWhenInUseAuthorization()` unconditionally — but per Apple's docs, that's a no-op when status is `.restricted` (the app cannot prompt for or change a restricted status), so `didChangeAuthorization` never fires and the pending result hangs forever. `onHasPermission` also reported plain `denied` (0) for `.restricted` while `onRequestPermission` already reported `deniedForever` (2) for it — the same platform-inconsistency #738 fixed for `.denied`, just not extended to `.restricted`. Added a shared `isPermissionDeniedOrRestricted` check and used it in both places.

## Verification

- `flutter build ios --simulator --no-codesign` and `flutter build macos --debug` in `packages/location/example` — both build clean.
- Reverted incidental `macos/Runner.xcodeproj` churn from the build so the diff is Swift-only.
- No iOS/macOS unit test harness exists in this repo to simulate `.restricted` authorization or a concurrent `requestPermission()`/`getLocation()` pair directly; verified by tracing every read/write of `permissionWanted`/`pendingLocationResults` and every comparison against `currentAuthorizationStatus` in the file to confirm the two branches are now symmetric with their already-correct granted-path counterparts.