### PR TITLE
fix(android): complete Built-in Kotlin migration (kotlinOptions → kotlin.compilerOptions)

### DIFF
--- a/packages/location/CHANGELOG.md
+++ b/packages/location/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 10.0.1
+
+### 🐛 Bug fixes
+
+- **Android:** Completed the migration to Flutter's Built-in Kotlin. The plugin
+  now configures the Kotlin compiler through the top-level `kotlin { compilerOptions {} }`
+  DSL instead of `android.kotlinOptions {}`, which is no longer available under
+  AGP 9's Built-in Kotlin. Combined with the existing conditional
+  `kotlin-android` apply, the plugin builds correctly on both AGP 8 (KGP) and
+  AGP 9 (Built-in Kotlin) (#1095).
+
 ## 10.0.0
 
 A major release with one breaking change (see below) plus a large batch of

--- a/packages/location/android/build.gradle
+++ b/packages/location/android/build.gradle
@@ -38,11 +38,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = "11"
-        // allWarningsAsErrors = true // TODO(bartekpacia): Re-enable
-    }
-
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
         test.java.srcDirs += "src/test/kotlin"
@@ -51,6 +46,16 @@ android {
     defaultConfig {
         minSdk = 21
         targetSdk = 36
+    }
+}
+
+// Use the top-level `kotlin` DSL instead of `android.kotlinOptions` so that the
+// compiler options resolve both with KGP (AGP < 9) and with AGP 9's built-in
+// Kotlin, where the `kotlinOptions` block is no longer available.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+        // allWarningsAsErrors = true // TODO(bartekpacia): Re-enable
     }
 }
 

--- a/packages/location/pubspec.yaml
+++ b/packages/location/pubspec.yaml
@@ -1,6 +1,6 @@
 name: location
 description: Cross-platform plugin for easy access to device's location in real-time.
-version: 10.0.0
+version: 10.0.1
 homepage: https://docs.page/Lyokone/flutterlocation
 repository: https://github.com/Lyokone/flutterlocation
 issue_tracker: https://github.com/Lyokone/flutterlocation/issues


### PR DESCRIPTION
## Summary

Fixes #1095.

v10.0.0 already made the `kotlin-android` (KGP) `apply` conditional on AGP < 9 (c41aca5), so the plugin no longer applies KGP under AGP 9's Built-in Kotlin. However the migration was **incomplete**: the `android { kotlinOptions {} }` block remained. That block is contributed by the `kotlin-android` plugin and is **not available under AGP 9's Built-in Kotlin**, so the plugin would fail to configure on AGP 9.

This PR moves the `jvmTarget` configuration to the top-level `kotlin { compilerOptions {} }` DSL, which resolves both with KGP (AGP < 9) and with Built-in Kotlin (AGP 9), per Flutter's [plugin-author migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

## Changes

- `android/build.gradle`: replace `android.kotlinOptions { jvmTarget = "11" }` with top-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }`.
- Bump to `10.0.1` + CHANGELOG entry.

## Notes

- The `kotlin {}` extension is available in both configurations: with KGP applied (AGP 8) and with Built-in Kotlin (AGP 9), so this is safe across the AGP range the plugin supports. Uses KGP 2.2.20 already declared in the buildscript.
- On AGP 8 the plugin still applies KGP (unavoidable — AGP 8 has no Built-in Kotlin), so the informational Flutter warning still appears there; it disappears once the app is on AGP 9 / Built-in Kotlin, which this change unblocks.