### PR TITLE
fix(e2e): make CI green by retrying flaky Patrol native automation (Android)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -72,13 +72,24 @@ jobs:
           # continuing onto the next line -- it's a naive per-line split
           # before the shell ever sees it. Every line below is therefore a
           # single, fully self-contained command with its own `cd`.
+          #
+          # Each `patrol test` is wrapped in an inline retry (up to 3 attempts)
+          # because Patrol's native UIAutomator automation is transiently flaky
+          # on the CI emulator: grantPermissionWhenInUse() intermittently gets
+          # "Invalid response: 404 -- selector button to allow permission while
+          # using found nothing" when the system permission dialog hasn't
+          # finished rendering the instant Patrol polls for it. The exact same
+          # test code passed on #1094 and failed on #1096 with no change to that
+          # path, so this is timing flake, not a real regression. The retry
+          # still `exit 1`s if all attempts fail, so a genuine break stays red.
+          # Keep each retry on a single physical line (see the split note above).
           script: |
             adb emu geo fix $TEST_LON $TEST_LAT
-            cd packages/location/example && patrol test --target integration_test/permission_flow_test.dart -d emulator-5554
-            cd packages/location/example && patrol test --target integration_test/get_location_test.dart -d emulator-5554
-            cd packages/location/example && patrol test --target integration_test/listen_location_test.dart -d emulator-5554
+            cd packages/location/example && n=0; until patrol test --target integration_test/permission_flow_test.dart -d emulator-5554; do n=$((n+1)); if [ "$n" -ge 3 ]; then echo "permission_flow_test still failing after $n attempts"; exit 1; fi; echo "Patrol native-automation flake; retry $n after 5s"; sleep 5; done
+            cd packages/location/example && n=0; until patrol test --target integration_test/get_location_test.dart -d emulator-5554; do n=$((n+1)); if [ "$n" -ge 3 ]; then echo "get_location_test still failing after $n attempts"; exit 1; fi; echo "Patrol native-automation flake; retry $n after 5s"; sleep 5; done
+            cd packages/location/example && n=0; until patrol test --target integration_test/listen_location_test.dart -d emulator-5554; do n=$((n+1)); if [ "$n" -ge 3 ]; then echo "listen_location_test still failing after $n attempts"; exit 1; fi; echo "Patrol native-automation flake; retry $n after 5s"; sleep 5; done
             adb shell cmd location set-location-enabled false
-            cd packages/location/example && patrol test --target integration_test/service_disabled_test.dart -d emulator-5554
+            cd packages/location/example && n=0; until patrol test --target integration_test/service_disabled_test.dart -d emulator-5554; do n=$((n+1)); if [ "$n" -ge 3 ]; then echo "service_disabled_test still failing after $n attempts"; exit 1; fi; echo "Patrol native-automation flake; retry $n after 5s"; sleep 5; done
             adb shell cmd location set-location-enabled true
 
   e2e-ios:


### PR DESCRIPTION
## Summary

Gets the PR CI green. After tracing every red job on #1096, **only one blocking job was actually failing the CI**: the `Android` job in the `e2e` workflow.

The `e2e` run reported `failure`, but its `iOS`, `Web`, `macOS` and `Windows` jobs are all already `continue-on-error: true` (documented upstream Patrol / platform limitations) — their red ❌ don't fail the run. `Linux` passed. The `location prepare` workflow already reports `success` (its only red job, `macOS`, is likewise non-blocking). So the whole thing was red **solely** because the one remaining blocking mobile gate — `Android` — flaked.

## Root cause

The Android job failed at:

```
grantPermissionWhenInUse() failed with Invalid response: 404
selector button to allow permission while using found nothing
```

That's Patrol's native UIAutomator not finding the Android system permission dialog button — a well-known transient emulator flake where the dialog hasn't finished rendering the instant Patrol polls for it. The app **built and ran fine**; the exact same test path **passed on #1094** and **failed on #1096** with no change to it. It's timing flake, not a regression.

## Change

Wrap each `patrol test` invocation in the Android job's script in an inline retry (up to 3 attempts, 5s apart). A genuine failure still `exit 1`s after the retries, so real breakage stays red — this only absorbs the transient native-automation flake.

- Validated the workflow YAML parses.
- Validated the retry one-liner under `sh -n` and dry-ran the loop (3 attempts → `exit 1` on persistent failure).
- Kept each retry on a single physical line, per the existing per-line-split constraint of `reactivecircus/android-emulator-runner` documented in the job.

## Not touched (deliberately)

The `iOS` / `Web` / `macOS` / `Windows` red ❌ are pre-existing, documented, and already non-blocking (`continue-on-error`), for genuine upstream/platform reasons (Patrol's macOS `Package.swift` bug, a missing iOS `RunnerUITests` target needing Xcode, a Windows headless-session permission limitation, an unidentified web `patrol` blocker). This PR intentionally leaves them as-is rather than papering over them.