### PR TITLE
fix(android): respect android.builtInKotlin flag when applying Kotlin plugin

### DIFF
--- a/packages/location/android/build.gradle
+++ b/packages/location/android/build.gradle
@@ -22,8 +22,16 @@ repositories {
 
 apply plugin: "com.android.library"
 
+// AGP 9 ships built-in Kotlin support, but it can be turned off with the
+// `android.builtInKotlin` Gradle property. Only skip applying the standalone
+// Kotlin Gradle plugin when built-in Kotlin is actually active; otherwise the
+// `kotlin { }` block below would have no backing extension. Mirrors the logic
+// used by other Flutter plugins (e.g. file_picker).
 def agpMajor = Integer.parseInt(com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.split("\\.")[0])
-if (agpMajor < 9) {
+def builtInKotlinProperty = providers.gradleProperty("android.builtInKotlin").orNull
+def builtInKotlinEnabled = agpMajor >= 9 &&
+    (builtInKotlinProperty == null || builtInKotlinProperty.toBoolean())
+if (!builtInKotlinEnabled) {
     apply plugin: "org.jetbrains.kotlin.android"
 }
 


### PR DESCRIPTION
… plugin

The plugin gated the standalone Kotlin Gradle plugin purely on the AGP major version (`agpMajor < 9`), assuming AGP 9 always implies built-in Kotlin. But built-in Kotlin can be disabled on AGP 9 via the `android.builtInKotlin` Gradle property. When it is off, neither KGP nor built-in Kotlin is applied, leaving the `kotlin { }` block with no backing extension and failing the build.

Check the flag in addition to the AGP version so the standalone plugin is applied whenever built-in Kotlin is not active. Mirrors the logic used by other Flutter plugins (e.g. file_picker).