### PR TITLE
Make LocationData.accuracy and LocationData.time non-nullable

### DIFF
--- a/packages/location/linux/location_plugin.cc
+++ b/packages/location/linux/location_plugin.cc
@@ -77,6 +77,13 @@ static FlValue* read_location(LocationPlugin* self, const gchar* location_path) 
     } else if (strcmp(key, "Heading") == 0) {
       fl_value_set_string_take(map, "heading",
                                fl_value_new_float(g_variant_get_double(value)));
+    } else if (strcmp(key, "Timestamp") == 0) {
+      uint64_t seconds = 0;
+      uint64_t microseconds = 0;
+      g_variant_get(value, "(tt)", &seconds, &microseconds);
+      double time_ms = static_cast<double>(seconds) * 1000.0 +
+                       static_cast<double>(microseconds) / 1000.0;
+      fl_value_set_string_take(map, "time", fl_value_new_float(time_ms));
     }
     g_variant_unref(value);
   }

--- a/packages/location/test/location_test.dart
+++ b/packages/location/test/location_test.dart
@@ -50,8 +50,8 @@ void main() {
   );
 
   test('getLocation should call the correct underlying instance', () async {
-    when(location.getLocation()).thenAnswer((_) => Future.value(
-        LocationData.fromMap({'latitude': 42.0, 'longitude': 2.0})));
+    when(location.getLocation()).thenAnswer((_) => Future.value(LocationData.fromMap(
+        {'latitude': 42.0, 'longitude': 2.0, 'accuracy': 1.0, 'time': 123456789.0})));
 
     await location.getLocation();
     verify(mockLocation.getLocation()).called(1);
@@ -60,8 +60,8 @@ void main() {
   test(
     'getLastKnownLocation should call the correct underlying instance',
     () async {
-      when(location.getLastKnownLocation()).thenAnswer((_) => Future.value(
-          LocationData.fromMap({'latitude': 42.0, 'longitude': 2.0})));
+      when(location.getLastKnownLocation()).thenAnswer((_) => Future.value(LocationData.fromMap(
+          {'latitude': 42.0, 'longitude': 2.0, 'accuracy': 1.0, 'time': 123456789.0})));
 
       await location.getLastKnownLocation();
       verify(mockLocation.getLastKnownLocation()).called(1);
@@ -131,12 +131,16 @@ void main() {
           LocationData.fromMap(<String, dynamic>{
             'latitude': 48.8534,
             'longitude': 2.3488,
+            'accuracy': 1.0,
+            'time': 123456789.0,
           }),
         )
         ..add(
           LocationData.fromMap(<String, dynamic>{
             'latitude': 42.8534,
             'longitude': 23.3488,
+            'accuracy': 1.0,
+            'time': 123456789.0,
           }),
         );
       unawaited(controller.close());
@@ -148,10 +152,14 @@ void main() {
             LocationData.fromMap(<String, dynamic>{
               'latitude': 48.8534,
               'longitude': 2.3488,
+              'accuracy': 1.0,
+              'time': 123456789.0,
             }),
             LocationData.fromMap(<String, dynamic>{
               'latitude': 42.8534,
               'longitude': 23.3488,
+              'accuracy': 1.0,
+              'time': 123456789.0,
             }),
             emitsDone,
           ],

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -26,12 +26,12 @@ class LocationData {
     return LocationData._(
       dataMap['latitude'] as double,
       dataMap['longitude'] as double,
-      dataMap['accuracy'] as double?,
+      dataMap['accuracy'] as double,
       dataMap['altitude'] as double?,
       dataMap['speed'] as double?,
       dataMap['speed_accuracy'] as double?,
       dataMap['heading'] as double?,
-      dataMap['time'] as double?,
+      dataMap['time'] as double,
       dataMap['isMock'] == 1,
       dataMap['isProducedByAccessory'] == 1,
       dataMap['verticalAccuracy'] as double?,
@@ -49,12 +49,12 @@ class LocationData {
     return LocationData._(
       (json['latitude'] as num).toDouble(),
       (json['longitude'] as num).toDouble(),
-      (json['accuracy'] as num?)?.toDouble(),
+      (json['accuracy'] as num).toDouble(),
       (json['altitude'] as num?)?.toDouble(),
       (json['speed'] as num?)?.toDouble(),
       (json['speedAccuracy'] as num?)?.toDouble(),
       (json['heading'] as num?)?.toDouble(),
-      (json['time'] as num?)?.toDouble(),
+      (json['time'] as num).toDouble(),
       json['isMock'] as bool?,
       json['isProducedByAccessory'] as bool?,
       (json['verticalAccuracy'] as num?)?.toDouble(),
@@ -72,10 +72,8 @@ class LocationData {
   /// Longitude, in degrees
   final double longitude;
 
-  /// Estimated horizontal accuracy of this location, radial, in meters
-  ///
-  /// Will be null if not available.
-  final double? accuracy;
+  /// Estimated horizontal accuracy of this location, radial, in meters.
+  final double accuracy;
 
   /// Estimated vertical accuracy of altitude, in meters.
   ///
@@ -103,8 +101,8 @@ class LocationData {
   /// Will be null if not available.
   final double? heading;
 
-  /// timestamp of the LocationData
-  final double? time;
+  /// timestamp of the LocationData, in milliseconds since epoch.
+  final double time;
 
   /// Is the location currently mocked
   ///

--- a/packages/location_platform_interface/lib/src/types.dart
+++ b/packages/location_platform_interface/lib/src/types.dart
@@ -101,7 +101,7 @@ class LocationData {
   /// Will be null if not available.
   final double? heading;
 
-  /// timestamp of the LocationData, in milliseconds since epoch.
+  /// Timestamp of the LocationData, in milliseconds since epoch.
   final double time;
 
   /// Is the location currently mocked

--- a/packages/location_platform_interface/test/method_channel_location_test.dart
+++ b/packages/location_platform_interface/test/method_channel_location_test.dart
@@ -34,6 +34,8 @@ void main() {
             return <String, dynamic>{
               'latitude': 48.8534,
               'longitude': 2.3488,
+              'accuracy': 1.0,
+              'time': 123456789.0,
             };
           case 'changeSettings':
             return 1;
@@ -212,6 +214,8 @@ void main() {
       controller.add(<String, dynamic>{
         'latitude': 48.8534,
         'longitude': 2.3488,
+        'accuracy': 1.0,
+        'time': 123456789.0,
       });
       var data = await queue.next;
       expect(data.latitude, 48.8534);
@@ -220,6 +224,8 @@ void main() {
       controller.add(<String, dynamic>{
         'latitude': 42.8534,
         'longitude': 23.3488,
+        'accuracy': 1.0,
+        'time': 123456789.0,
       });
       data = await queue.next;
       expect(data.latitude, 42.8534);

--- a/packages/location_platform_interface/test/types_test.dart
+++ b/packages/location_platform_interface/test/types_test.dart
@@ -7,6 +7,8 @@ void main() {
       final locationData = LocationData.fromMap(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
       });
       expect(
         locationData.toString(),
@@ -133,11 +135,13 @@ void main() {
     });
 
     test('fromJson(toJson) round-trips with null fields', () {
-      // latitude/longitude are non-nullable, so they're the only fields that
+      // latitude/longitude/accuracy/time are non-nullable, so they're the only fields that
       // must be present; everything else round-trips through its null default.
       final locationData = LocationData.fromJson(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
       });
 
       expect(LocationData.fromJson(locationData.toJson()), locationData);
@@ -147,6 +151,8 @@ void main() {
       final locationData = LocationData.fromJson(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
         'provider': 'gps',
       });
 
@@ -166,6 +172,8 @@ void main() {
       final accessoryLocation = LocationData.fromMap(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
         'isProducedByAccessory': 1,
       });
       expect(accessoryLocation.isProducedByAccessory, true);
@@ -173,6 +181,8 @@ void main() {
       final deviceLocation = LocationData.fromMap(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
         'isProducedByAccessory': 0,
       });
       expect(deviceLocation.isProducedByAccessory, false);
@@ -181,6 +191,8 @@ void main() {
       final missingLocation = LocationData.fromMap(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
       });
       expect(missingLocation.isProducedByAccessory, false);
     });
@@ -189,11 +201,15 @@ void main() {
       final accessoryLocation = LocationData.fromMap(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
         'isProducedByAccessory': 1,
       });
       final deviceLocation = LocationData.fromMap(<String, dynamic>{
         'latitude': 42.0,
         'longitude': 2.0,
+        'accuracy': 1.0,
+        'time': 123456789.0,
         'isProducedByAccessory': 0,
       });
 


### PR DESCRIPTION
This PR makes `LocationData.accuracy` and `LocationData.time` non-nullable (`double` instead of `double?`).

Every platform implementation now consistently provides both values:
*   **Android:** Always provides both (via `Location.getAccuracy()` and `Location.getTime()`).
*   **iOS/macOS:** Always provides both (via `CLLocation.horizontalAccuracy` and `CLLocation.timestamp`).
*   **Web:** Always provides both (via `GeolocationCoordinates.accuracy` and `GeolocationPosition.timestamp`).
*   **Windows:** Always provides both (via `Geocoordinate.Accuracy` and `Geocoordinate.Timestamp`).
*   **Linux:** Updated in this PR to populate `time` (derived from GeoClue2 `Timestamp` property). Previously, `time` was omitted on Linux (resulting in `null` in Dart).

As a result, `accuracy` and `time` are now guaranteed to be present in `LocationData`.

### 💥 Breaking Change
This is a breaking change for:
*   Users of `LocationData.fromMap` or `LocationData.fromJson` who omit `accuracy` or `time` in the map/json.
*   Test doubles/mocks that construct `LocationData` without these fields.

All package tests have been updated to include these fields in mock data.
